### PR TITLE
Add include_module into defun-type-regexp

### DIFF
--- a/neocaml.el
+++ b/neocaml.el
@@ -368,6 +368,8 @@ Infix operators are parsed and fontified separately.")
                 "value_specification"
                 "method_definition"
                 "method_specification"
+                "include_module"
+                "include_module_type"
                 "instance_variable_definition"
                 "instance_variable_specification"
                 "module_binding"


### PR DESCRIPTION
This appears when you use `include Module` inside either an ml or mli file and should be considered a top-level defun.