### PR TITLE
Add Emacs snapshot (31) to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         emacs-version:
           - 29.4
           - 30.1
+          - snapshot
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
PR #3 fixed a when-let warning that only shows up on Emacs 31. Adding the development snapshot to CI so we catch these earlier.