### PR TITLE
Add indentation support for binding operators (let*, and*)

### DIFF
--- a/neocaml.el
+++ b/neocaml.el
@@ -458,6 +458,9 @@ The return value is suitable for `treesit-simple-indent-rules'."
      ;; let...in: body after "in" aligns with "let" (no accumulation)
      ((parent-is "let_expression") parent-bol 0)
 
+     ;; Binding operators: and* / and+ align with let* / let+
+     ((node-is "let_and_operator") parent-bol 0)
+
      ;; Let/type/external bindings: body after = is indented
      ((parent-is "let_binding") parent-bol neocaml-indent-offset)
      ((parent-is "type_binding") parent-bol neocaml-indent-offset)

--- a/test/neocaml-indentation-test.el
+++ b/test/neocaml-indentation-test.el
@@ -166,6 +166,33 @@ x + y")
   let y = 2 in
   x + y")
 
+  (when-indenting-it "indents let* binding operator chain"
+    "let () =
+  let* x = foo in
+  let* y = bar in
+  x + y")
+
+  (when-indenting-it "indents let+ binding operator"
+    "let () =
+  let+ x = foo in
+  x + 1")
+
+  (when-indenting-it "indents let* with multiline body"
+    "let main () =
+  let* response =
+    Http.get url
+  in
+  let* body =
+    Response.body response
+  in
+  print_endline body")
+
+  (when-indenting-it "indents and* binding operator"
+    "let () =
+  let* x = foo
+  and* y = bar in
+  x + y")
+
   (when-indenting-it "indents a match expression"
     "match x with
 | A -> 1

--- a/test/resources/sample.ml
+++ b/test/resources/sample.ml
@@ -110,5 +110,26 @@ let describe_pair = function
   | (0, y) -> Printf.sprintf "y-axis at %d" y
   | (x, y) -> Printf.sprintf "(%d, %d)" x y
 
+(* Binding operators — monadic let* *)
+let ( let* ) o f = match o with None -> None | Some x -> f x
+
+let find_and_sum tbl k1 k2 =
+  let* x1 = Hashtbl.find_opt tbl k1 in
+  let* x2 = Hashtbl.find_opt tbl k2 in
+  Some (x1 + x2)
+
+(* Binding operators — applicative let+ and+ *)
+let ( let+ ) o f = Option.map f o
+let ( and+ ) a b = match a, b with Some x, Some y -> Some (x, y) | _ -> None
+
+let add_opts a b =
+  let+ x = a and+ y = b in
+  x + y
+
+(* Binding operators — chained and+ *)
+let sum3 a b c =
+  let+ x = a and+ y = b and+ z = c in
+  x + y + z
+
 (* Line number directive *)
 # 1 "generated.ml"


### PR DESCRIPTION
The let*/let+/and*/and+ binding operators now indent correctly. The and*/and+ keyword was missing an indent rule, causing it to fall to column 0 instead of aligning with its let*/let+ counterpart.

Adds four indentation tests covering let*, let+, multiline let* bodies, and and*.

Addresses feedback from #2.