### PR TITLE
Improve utop support in the REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- Improve `utop` support: strip ANSI escape sequences and recognize utop's prompt format so point is correctly placed after the prompt.
 - Make `C-c C-z` reversible: from a source buffer it switches to the REPL, from the REPL it switches back.
 - Add `_build` directory awareness: when opening a file under `_build/`, offer to switch to the source copy (supports dune and ocamlbuild layouts).
 - Split `neocaml-prettify-symbols-alist` into a column-width-safe base list and `neocaml-prettify-symbols-extra-alist` (`fun`->λ, `->`->→, `not`->¬).  Control extra symbols with the `neocaml-prettify-symbols-full` toggle.

--- a/neocaml-repl.el
+++ b/neocaml-repl.el
@@ -76,8 +76,8 @@ Used by `neocaml-repl-switch-to-source' to return to the source buffer.")
     ;; values and types from result
     ("\\(val\\) \\([^:]*\\)\\( *:\\)" (1 font-lock-keyword-face) (2 font-lock-variable-name-face))
     ("\\(type\\) \\([^ =]*\\)" (1 font-lock-keyword-face) (2 font-lock-type-face))
-    ;; prompt
-    ("^# " . font-lock-comment-face))
+    ;; prompt (standard "# " and utop's "utop # " / "utop[0] # ")
+    ("^\\(utop\\(\\[[0-9]+\\]\\)? \\)?# " . font-lock-comment-face))
   "Font-lock keywords for the OCaml REPL buffer.
 Highlights prompts, errors, warnings, and toplevel response values.")
 
@@ -85,10 +85,13 @@ Highlights prompts, errors, warnings, and toplevel response values.")
   "Major mode for interacting with an OCaml toplevel.
 
 \\{neocaml-repl-mode-map}"
-  (setq comint-prompt-regexp "^# ")
+  ;; Match both the standard "# " prompt and utop's "utop # " / "utop[0] # "
+  (setq comint-prompt-regexp "^\\(utop\\(\\[[0-9]+\\]\\)? \\)?# ")
   (setq comint-prompt-read-only t)
   (setq comint-input-sender 'neocaml-repl--input-sender)
   (setq comint-process-echoes nil)
+  ;; Strip ANSI escape sequences emitted by utop and other enhanced toplevels
+  (ansi-color-for-comint-mode-on)
   (setq-local comment-start "(* ")
   (setq-local comment-end " *)")
   (setq-local comment-start-skip "(\\*+[ \t]*")


### PR DESCRIPTION
Fixes point not being placed after the prompt when using utop as the REPL program. Two changes:

- Enable `ansi-color-for-comint-mode-on` to strip ANSI escape sequences that utop emits
- Broaden `comint-prompt-regexp` and the font-lock prompt pattern to recognize utop's prompt format (`utop # `, `utop[0] # `) alongside the standard `# `

Addresses feedback from #2.