### PR TITLE
Introduce neocaml-base-mode as shared parent for both major modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- Introduce `neocaml-base-mode` as the shared parent for `neocaml-mode` and `neocaml-interface-mode`.  Users can hook into `neocaml-base-mode-hook` to configure both modes at once.
 - Improve `utop` support: strip ANSI escape sequences and recognize utop's prompt format so point is correctly placed after the prompt.
 - Make `C-c C-z` reversible: from a source buffer it switches to the REPL, from the REPL it switches back.
 - Add `_build` directory awareness: when opening a file under `_build/`, offer to switch to the source copy (supports dune and ocamlbuild layouts).

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ more. It works with neocaml out of the box:
 (use-package ocaml-eglot
   :ensure t
   :hook
-  ((neocaml-mode neocaml-interface-mode) . ocaml-eglot)
+  (neocaml-base-mode . ocaml-eglot)
   (ocaml-eglot . eglot-ensure))
 ```
 
@@ -194,7 +194,8 @@ You can "prettify" certain symbols (see `neocaml-prettify-symbols-alist`) by
 enabling `prettify-symbols-mode` via a hook:
 
 ```emacs-lisp
-(add-hook 'neocaml-mode-hook #'prettify-symbols-mode)
+;; Enable for both .ml and .mli files at once
+(add-hook 'neocaml-base-mode-hook #'prettify-symbols-mode)
 ```
 
 When it comes to indentation you've got several options:
@@ -213,7 +214,8 @@ You can change the indention function used by Neocaml like this:
   "Set up my custom indentation for neocaml-mode."
   (setq-local indent-line-function 'indent-relative))
 
-(add-hook 'neocaml-mode-hook 'my-neocaml-mode-setup)
+;; Use neocaml-base-mode-hook to apply to both .ml and .mli files
+(add-hook 'neocaml-base-mode-hook 'my-neocaml-mode-setup)
 ```
 
 ## Toplevel (REPL) Integration
@@ -224,7 +226,8 @@ You can also start a OCaml REPL (toplevel) and interact with it using
 `neocaml-repl-minor-mode`. You can enable the mode like this:
 
 ``` emacs-lisp
-(add-hook 'neocaml-mode-hook #'neocaml-repl-minor-mode)
+;; Enable for both .ml and .mli files at once
+(add-hook 'neocaml-base-mode-hook #'neocaml-repl-minor-mode)
 ```
 
 If you're using `use-package` you'd probably do something like:
@@ -233,7 +236,7 @@ If you're using `use-package` you'd probably do something like:
 (use-package neocaml
   :vc (:url "https://github.com/bbatsov/neocaml" :rev :newest)
   :config
-  (add-hook 'neocaml-mode-hook #'neocaml-repl-minor-mode)
+  (add-hook 'neocaml-base-mode-hook #'neocaml-repl-minor-mode)
   ;; other config options...
   )
 ```


### PR DESCRIPTION
Both neocaml-mode and neocaml-interface-mode now derive from neocaml-base-mode instead of prog-mode directly. The base mode holds shared setup (syntax table, comments, compilation, navigation, prettify-symbols, keybindings), while the concrete modes only set imenu and call neocaml--setup-mode with their grammar.

Benefits:
- neocaml-base-mode-hook fires for both .ml and .mli files
- (derived-mode-p 'neocaml-base-mode) matches both modes
- Follows the established pattern from c-ts-mode / c++-ts-mode in Emacs core

Addresses feedback from #2.