### PR TITLE
Fix compile-goto-error column offset by one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### Bug fixes
+
+- Fix `compile-goto-error` landing one column before the actual error position.  OCaml uses 0-indexed columns; `compilation-first-column` is now set to 0 accordingly.
+
 ### Changes
 
 - Introduce `neocaml-base-mode` as the shared parent for `neocaml-mode` and `neocaml-interface-mode`.  Users can hook into `neocaml-base-mode-hook` to configure both modes at once.

--- a/neocaml.el
+++ b/neocaml.el
@@ -767,6 +767,8 @@ OCaml uses exclusive end-columns but Emacs expects inclusive ones."
 (defun neocaml--setup-compilation ()
   "Register OCaml compilation error regexp with compile.el."
   (require 'compile)
+  ;; OCaml uses 0-indexed character positions in error messages.
+  (setq-local compilation-first-column 0)
   (setq compilation-error-regexp-alist-alist
         (assq-delete-all 'ocaml compilation-error-regexp-alist-alist))
   (push `(ocaml

--- a/test/neocaml-compilation-test.el
+++ b/test/neocaml-compilation-test.el
@@ -128,6 +128,11 @@ Returns nil if the regexp does not match."
       (expect (plist-get info :line) :to-equal 1)
       (expect (plist-get info :col) :to-be nil)))
 
+  (it "sets compilation-first-column to 0 for OCaml's 0-indexed columns"
+    (with-temp-buffer
+      (neocaml-mode)
+      (expect compilation-first-column :to-equal 0)))
+
   (it "computes end-column correctly"
     (with-temp-buffer
       (insert "File \"foo.ml\", line 4, characters 6-20:\nError: type error\n")


### PR DESCRIPTION
OCaml reports 0-indexed character positions in error messages, but Emacs's `compilation-first-column` defaults to 1. This caused `compile-goto-error` to land one column before the actual error (e.g. on the space before an identifier instead of the identifier itself).

Sets `compilation-first-column` to 0, matching what tuareg does.

Fixes #8