### PR TITLE
[Fix #20] Work around broken transpose-sexps on Emacs 30

### DIFF
--- a/neocaml.el
+++ b/neocaml.el
@@ -929,6 +929,9 @@ SOFT works the same as in `comment-indent-new-line'."
          ["Find Interface/Implementation" ff-find-other-file]
          ["Find Interface/Implementation in other window" ff-find-other-file-other-window])
         "--"
+        ["Transpose Expression" transpose-sexps]
+        ["Transpose Statement" transpose-sentences]
+        "--"
         ["Compile..." compile]
         ["Cycle indent function" neocaml-cycle-indent-function]
         ["Install tree-sitter grammars" neocaml-install-grammars]


### PR DESCRIPTION
treesit-transpose-sexps in Emacs 30 picks the wrong AST level when using treesit-thing-settings, causing "Don't have two things to transpose" errors in many common cases. This falls back to transpose-sexps-default-function on Emacs 30; Emacs 31 has a proper fix (bug#60655).

Same workaround used by clojure-ts-mode.

Fixes #20