### PR TITLE
Fix delete-pair and list navigation for delimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#27](https://github.com/bbatsov/neocaml/issues/27): `neocaml-install-grammars` now accepts a prefix argument (`C-u`) to force reinstallation of grammars, even if they are already installed.
 - Avoid the superfluous spaces after the prompt of the REPL when sending code to
   the REPL via the commands `neocaml-repl-send-*`.
+- [#28](https://github.com/bbatsov/neocaml/issues/28): Fix `delete-pair` deleting the wrong closing delimiter. Add a `list` thing to `treesit-thing-settings` and a hybrid `forward-sexp` that falls back to syntax-table matching on delimiter characters.
 
 ### New features
 

--- a/neocaml.el
+++ b/neocaml.el
@@ -742,13 +742,87 @@ to be used as `forward-sexp-function'."
       (treesit-beginning-of-thing neocaml--block-regex (- count))
     (treesit-end-of-thing neocaml--block-regex count)))
 
+(defun neocaml--delimiter-p ()
+  "Return non-nil if point is on a delimiter character."
+  (let ((syntax (syntax-after (point))))
+    (and syntax
+         (memq (syntax-class syntax) '(4 5)))))  ; 4=open, 5=close
+
+(defun neocaml--forward-sexp-hybrid (arg)
+  "Hybrid `forward-sexp-function' combining tree-sitter and syntax table.
+When point is on a delimiter character (paren, bracket, brace),
+fall back to syntax-table-based matching so that commands like
+`delete-pair' find the correct matching delimiter.  Otherwise,
+use tree-sitter sexp navigation.
+
+This function is used on Emacs 29 and 30.  Emacs 31+ handles
+this natively via the `list' thing in `treesit-thing-settings'.
+
+ARG is as in `forward-sexp-function'."
+  (let ((arg (or arg 1)))
+    (if (or (neocaml--delimiter-p)
+            ;; Moving backward: check if the character before point
+            ;; (skipping whitespace) is a closing delimiter.
+            (and (< arg 0)
+                 (save-excursion
+                   (skip-chars-backward " \t")
+                   (not (bobp))
+                   (let ((syntax (syntax-after (1- (point)))))
+                     (and syntax (eq (syntax-class syntax) 5))))))
+        ;; On a delimiter: use syntax-table paren matching.
+        ;; `forward-sexp-default-function' wraps `scan-sexps' but is
+        ;; only available from Emacs 30; fall back to raw `scan-sexps'
+        ;; on Emacs 29.
+        (if (fboundp 'forward-sexp-default-function)
+            (forward-sexp-default-function arg)
+          (goto-char (or (scan-sexps (point) arg) (buffer-end arg))))
+      ;; Not on a delimiter: use tree-sitter node navigation.
+      ;; `treesit-forward-sexp' is available from Emacs 30; on Emacs 29
+      ;; fall back to the simpler `neocaml-forward-sexp'.
+      (if (fboundp 'treesit-forward-sexp)
+          (treesit-forward-sexp arg)
+        (neocaml-forward-sexp arg)))))
+
 (defun neocaml--thing-settings (language)
   "Return `treesit-thing-settings' definitions for LANGUAGE.
-Configures sexp, sentence, text, and comment navigation."
+Configures sexp, list, sentence, text, and comment navigation.
+
+The `list' thing covers delimited container nodes (parentheses,
+brackets, braces, arrays).  On Emacs 31+, defining it causes
+`treesit-major-mode-setup' to use the hybrid
+`treesit-forward-sexp-list' for `forward-sexp-function', which
+falls back to syntax-table matching for delimiter characters.
+This makes commands like `delete-pair' work correctly."
   `((,language
      (sexp (not ,(rx (or "{" "}" "(" ")" "[" "]" "[|" "|]"
                          "," "." ";" ";;" ":" "::" ":>" "->"
                          "<-" "=" "|" ".."))))
+     (list ,(regexp-opt '("parenthesized_expression"
+                          "parenthesized_operator"
+                          "parenthesized_pattern"
+                          "parenthesized_type"
+                          "parenthesized_class_expression"
+                          "parenthesized_module_expression"
+                          "parenthesized_module_type"
+                          "list_expression"
+                          "list_pattern"
+                          "list_binding_pattern"
+                          "array_expression"
+                          "array_pattern"
+                          "array_binding_pattern"
+                          "record_expression"
+                          "record_pattern"
+                          "record_binding_pattern"
+                          "record_declaration"
+                          "object_expression"
+                          "object_type"
+                          "object_copy_expression"
+                          "polymorphic_variant_type"
+                          "package_type"
+                          "signature"
+                          "structure"
+                          "class_body_type")
+                        'symbols))
      (sentence ,(regexp-opt '("value_definition"
                               "type_definition"
                               "exception_definition"
@@ -1118,6 +1192,14 @@ the language-specific parts of the mode."
 
     (treesit-major-mode-setup)
 
+    ;; On Emacs 30, treesit-major-mode-setup sets forward-sexp-function
+    ;; to treesit-forward-sexp, which doesn't fall back to scan-sexps
+    ;; for delimiter characters.  This breaks commands like delete-pair.
+    ;; Use a hybrid function that delegates to scan-sexps on delimiters.
+    ;; Emacs 31+ handles this natively via the `list' thing.
+    (unless (fboundp 'treesit-forward-sexp-list)
+      (setq-local forward-sexp-function #'neocaml--forward-sexp-hybrid))
+
     ;; Workaround for treesit-transpose-sexps being broken on Emacs 30
     ;; (bug#60655).  Emacs 31 rewrites the function to work correctly.
     (when (and (fboundp 'transpose-sexps-default-function)
@@ -1155,9 +1237,10 @@ for .ml files and `neocaml-interface-mode' for .mli files."
 
   (setq-local indent-line-function #'treesit-indent)
 
-  ;; Fallback for Emacs 29 (no treesit-thing-settings)
+  ;; Emacs 29 has no treesit-thing-settings, so treesit-major-mode-setup
+  ;; won't configure forward-sexp.  Set the hybrid function directly.
   (unless (boundp 'treesit-thing-settings)
-    (setq-local forward-sexp-function #'neocaml-forward-sexp))
+    (setq-local forward-sexp-function #'neocaml--forward-sexp-hybrid))
   (setq-local treesit-defun-type-regexp
               (cons neocaml--defun-type-regexp
                     #'neocaml--defun-valid-p))

--- a/test/neocaml-navigation-test.el
+++ b/test/neocaml-navigation-test.el
@@ -222,4 +222,76 @@
                            (point)))
               :to-be-truthy))))
 
+;;;; list navigation (Emacs 30+ only)
+
+(describe "navigation: list (Emacs 30+)"
+  (before-all
+    (unless (treesit-language-available-p 'ocaml)
+      (signal 'buttercup-pending "tree-sitter OCaml grammar not available"))
+    (unless (boundp 'treesit-thing-settings)
+      (signal 'buttercup-pending "treesit-thing-settings not available (requires Emacs 30+)")))
+
+  (it "forward-list moves over a parenthesized expression"
+    (with-neocaml-buffer "let x = (1 + 2) + 3\n"
+      (search-forward "= ")
+      (forward-list)
+      (expect (char-before) :to-equal ?\))))
+
+  (it "forward-list moves over a list expression"
+    (with-neocaml-buffer "let x = [1; 2; 3]\n"
+      (search-forward "= ")
+      (forward-list)
+      (expect (char-before) :to-equal ?\])))
+
+  (it "forward-list moves over a record expression"
+    (with-neocaml-buffer "let x = {a = 1; b = 2}\n"
+      (search-forward "= ")
+      (forward-list)
+      (expect (char-before) :to-equal ?})))
+
+  (it "forward-list moves over an array expression"
+    (with-neocaml-buffer "let x = [|1; 2; 3|]\n"
+      (search-forward "= ")
+      (forward-list)
+      (expect (looking-back "\\|\\]" (- (point) 2)) :to-be-truthy)))
+
+  (it "up-list moves out of a parenthesized expression"
+    (with-neocaml-buffer "let x = (1 + 2)\n"
+      (search-forward "1 ")
+      (up-list)
+      (expect (char-before) :to-equal ?\))))
+
+  (it "down-list moves into a parenthesized expression"
+    (with-neocaml-buffer "let x = (1 + 2)\n"
+      (search-forward "= ")
+      (down-list)
+      (expect (char-before) :to-equal ?\()))
+
+  (it "forward-list moves over a polymorphic variant type"
+    (with-neocaml-buffer "type t = [ `Foo | `Bar ]\n"
+      (search-forward "= ")
+      (forward-list)
+      (expect (char-before) :to-equal ?\])))
+
+  (it "forward-list moves over a package type"
+    (with-neocaml-buffer "type t = (module S)\n"
+      (search-forward "= ")
+      (forward-list)
+      (expect (char-before) :to-equal ?\))))
+
+  (it "delete-pair removes matching parentheses"
+    (with-neocaml-buffer "let x = (1 + 2)\n"
+      (search-forward "= ")
+      (delete-pair)
+      (expect (buffer-string) :to-equal "let x = 1 + 2\n")))
+
+  (it "delete-pair removes correct parens in nested code"
+    (with-neocaml-buffer "let _ =\n  (let world = \"world\" in\n   Printf.printf \"Hello %s\\n\" world);\n  ()\n"
+      (search-forward "  (let")
+      (backward-char 4) ;; point on the opening paren before "let"
+      (delete-pair)
+      ;; The semicolon paren should still be intact, and () at the end too
+      (expect (buffer-string) :to-match "let world")
+      (expect (buffer-string) :to-match "()"))))
+
 ;;; neocaml-navigation-test.el ends here


### PR DESCRIPTION
Fixes #28.

`delete-pair` was deleting the wrong closing delimiter because
`forward-sexp` used tree-sitter node navigation instead of
syntax-table paren matching when point was on a delimiter character.

Two changes here:

- Added a `list` thing to `treesit-thing-settings` covering OCaml's
  container/delimited node types. On Emacs 31+ this gives us native
  `forward-list`, `up-list`, `down-list` and the hybrid
  `treesit-forward-sexp-list` for free.

- For Emacs 29-30 (where the `list` thing isn't wired up by
  `treesit-major-mode-setup`), added `neocaml--forward-sexp-hybrid`
  that falls back to `scan-sexps` when point is on a delimiter.
  This follows the same approach Emacs 31 takes internally.