### PR TITLE
Allow forcing grammar reinstallation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### Bug fixes
+
+- [#27](https://github.com/bbatsov/neocaml/issues/27): `neocaml-install-grammars` now accepts a prefix argument (`C-u`) to force reinstallation of grammars, even if they are already installed.
+
 ### New features
 
 - Add `neocaml-objinfo-mode` for viewing OCaml compiled artifacts (`.cmi`, `.cmo`, `.cmx`, `.cma`, `.cmxa`, `.cmxs`, `.cmt`, `.cmti`) via `ocamlobjinfo`. Includes font-lock, imenu navigation, and revert support.

--- a/neocaml.el
+++ b/neocaml.el
@@ -133,12 +133,15 @@ displaying it."
 Each entry is a list of (LANGUAGE URL REV SOURCE-DIR).
 Suitable for use as the value of `treesit-language-source-alist'.")
 
-(defun neocaml-install-grammars ()
-  "Install required language grammars if not already available."
-  (interactive)
+(defun neocaml-install-grammars (&optional force)
+  "Install required language grammars if not already available.
+With prefix argument FORCE, reinstall grammars even if they are
+already installed.  This is useful after upgrading neocaml to a
+version that requires a newer grammar."
+  (interactive "P")
   (dolist (recipe neocaml-grammar-recipes)
     (let ((grammar (car recipe)))
-      (unless (treesit-language-available-p grammar nil)
+      (when (or force (not (treesit-language-available-p grammar nil)))
         (message "Installing %s tree-sitter grammar..." grammar)
         ;; `treesit-language-source-alist' is dynamically scoped.
         ;; Binding it in this let expression allows
@@ -170,7 +173,7 @@ Emit a warning if an outdated grammar is detected."
               (display-warning
                'neocaml
                (format "The installed tree-sitter OCaml grammar appears older \
-than %s.  Run M-x neocaml-install-grammars to update."
+than %s.  Run C-u M-x neocaml-install-grammars to reinstall."
                        expected)))))))))
 
 ;; adapted from tuareg-mode

--- a/test/neocaml-grammar-test.el
+++ b/test/neocaml-grammar-test.el
@@ -36,6 +36,12 @@
     (neocaml-install-grammars)
     (expect 'treesit-install-language-grammar :to-have-been-called-times 2))
 
+  (it "reinstalls all grammars when FORCE is non-nil"
+    (spy-on 'treesit-language-available-p :and-return-value t)
+    (spy-on 'treesit-install-language-grammar)
+    (neocaml-install-grammars t)
+    (expect 'treesit-install-language-grammar :to-have-been-called-times 2))
+
   (it "binds treesit-language-source-alist to neocaml-grammar-recipes"
     (let (captured-alist)
       (spy-on 'treesit-language-available-p :and-return-value nil)


### PR DESCRIPTION
Fixes #27.

`neocaml-install-grammars` was skipping already-installed grammars, so
users upgrading to a version that requires a newer grammar had no way
to reinstall them. Now `C-u M-x neocaml-install-grammars` forces
reinstallation. The compatibility warning message has been updated to
mention this.