### PR TITLE
Add dune format-dune-file integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,20 @@ mode** (`--watch`), rebuilding automatically when files change. For example,
 The project root is determined by walking up from the current file to find
 `dune-project`.
 
+### dune File Formatting
+
+`neocaml-dune-mode` can format the current buffer using `dune format-dune-file`.
+Use `C-c C-f` (`neocaml-dune-format-buffer`) to format on demand, or enable
+automatic formatting on save:
+
+```emacs-lisp
+(setq neocaml-dune-format-on-save t)
+```
+
+Note: this formats individual dune files via `dune format-dune-file`, which is
+different from `dune fmt` (available via `C-c C-d f`) that formats the entire
+project.
+
 ## Comparison with Other Modes
 
 People love comparisons, so here's a comparison of neocaml with its main historical

--- a/neocaml-dune.el
+++ b/neocaml-dune.el
@@ -51,6 +51,13 @@ Dune files conventionally use 1-space indentation."
   :group 'neocaml-dune
   :package-version '(neocaml . "0.6.0"))
 
+(defcustom neocaml-dune-format-on-save nil
+  "When non-nil, format the buffer with `dune format-dune-file' before saving."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'neocaml-dune
+  :package-version '(neocaml . "0.8.0"))
+
 ;;; Grammar installation
 
 (defconst neocaml-dune-grammar-recipes
@@ -69,6 +76,36 @@ With prefix argument FORCE, reinstall even if already installed."
     (message "Installing dune tree-sitter grammar...")
     (let ((treesit-language-source-alist neocaml-dune-grammar-recipes))
       (treesit-install-language-grammar 'dune))))
+
+;;; Formatting
+
+(defun neocaml-dune-format-buffer ()
+  "Format the current buffer using `dune format-dune-file'.
+Pipes the buffer content through the command and replaces the
+buffer text with the formatted output, preserving point."
+  (interactive)
+  (let ((outbuf (generate-new-buffer " *neocaml-dune-format*"))
+        (orig-point (point))
+        (orig-window-start (window-start)))
+    (unwind-protect
+        (let ((exit-code (call-process-region (point-min) (point-max)
+                                              "dune" nil outbuf nil
+                                              "format-dune-file")))
+          (if (zerop exit-code)
+              (progn
+                (erase-buffer)
+                (insert-buffer-substring outbuf)
+                (goto-char (min orig-point (point-max)))
+                (set-window-start (selected-window) orig-window-start))
+            (user-error "Dune format-dune-file failed: %s"
+                        (with-current-buffer outbuf
+                          (string-trim (buffer-string))))))
+      (kill-buffer outbuf))))
+
+(defun neocaml-dune--format-before-save ()
+  "Format the buffer before saving if `neocaml-dune-format-on-save' is non-nil."
+  (when neocaml-dune-format-on-save
+    (neocaml-dune-format-buffer)))
 
 ;;; Font-lock
 
@@ -225,10 +262,15 @@ tree-sitter >= 0.25.0" (treesit-library-abi-version)))
   ;; which-func-mode / add-log integration
   (setq-local add-log-current-defun-function #'treesit-add-log-current-defun)
 
+  ;; Format on save
+  (add-hook 'before-save-hook #'neocaml-dune--format-before-save nil t)
+
   ;; Final newline
   (setq-local require-final-newline mode-require-final-newline)
 
   (treesit-major-mode-setup))
+
+(define-key neocaml-dune-mode-map (kbd "C-c C-f") #'neocaml-dune-format-buffer)
 
 ;;;###autoload
 (progn

--- a/test/neocaml-dune-test.el
+++ b/test/neocaml-dune-test.el
@@ -203,4 +203,29 @@ DESCRIPTION is the test name.  Uses `neocaml-dune-mode'."
         (expect (get-text-property (match-beginning 0) 'face)
                 :to-equal 'font-lock-comment-face)))))
 
+(describe "neocaml-dune-format-buffer"
+  (before-all
+    (unless (treesit-language-available-p 'dune)
+      (signal 'buttercup-pending "tree-sitter dune grammar not available")))
+
+  (it "formats an unformatted dune buffer"
+    (unless (executable-find "dune")
+      (signal 'buttercup-pending "dune executable not found"))
+    (with-temp-buffer
+      (insert "(library (name foo) (libraries bar baz))")
+      (neocaml-dune-mode)
+      (neocaml-dune-format-buffer)
+      (expect (string-trim (buffer-string))
+              :to-equal "(library\n (name foo)\n (libraries bar baz))")))
+
+  (it "preserves an already-formatted buffer"
+    (unless (executable-find "dune")
+      (signal 'buttercup-pending "dune executable not found"))
+    (let ((formatted "(library\n (name foo)\n (libraries bar baz))\n"))
+      (with-temp-buffer
+        (insert formatted)
+        (neocaml-dune-mode)
+        (neocaml-dune-format-buffer)
+        (expect (buffer-string) :to-equal formatted)))))
+
 ;;; neocaml-dune-test.el ends here


### PR DESCRIPTION
Adds `neocaml-dune-format-buffer` (bound to `C-c C-f`) to format the current dune buffer via `dune format-dune-file`, plus a `neocaml-dune-format-on-save` option for automatic formatting before save.

Inspired by the VS Code OCaml Platform extension which provides the same feature.