### PR TITLE
Add neocaml-cram-mode for cram test files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ One last thing - we really need more Emacs packages with fun names! :D
 - dune build commands (`neocaml-dune-interaction-mode`) — build, test, clean, promote, fmt, exec (with watch mode via prefix arg)
 - OCamllex file editing (`neocaml-ocamllex-mode`) with font-lock, indentation, imenu, and OCaml language injection (Emacs 30+)
 - Menhir file editing (`neocaml-menhir-mode`) with font-lock, indentation, imenu, and OCaml language injection (Emacs 30+)
+- Cram test file editing (`neocaml-cram-mode`) with font-lock for commands, output, modifiers, and prose
 - Easy installation of `ocaml` and `ocaml-interface` tree-sitter grammars via `M-x neocaml-install-grammars`
 - Compilation error regexp for `M-x compile` (errors, warnings, alerts, backtraces)
 - `_build` directory awareness (offers to switch to source when opening build artifacts)
@@ -601,6 +602,30 @@ Note: this formats individual dune files via `dune format-dune-file`, which is
 different from `dune fmt` (available via `C-c C-d f`) that formats the entire
 project.
 
+### Cram Tests
+
+`neocaml-cram-mode` provides syntax highlighting for cram test (`.t`) files, as
+used by dune's expect-test framework. It highlights shell commands, expected
+output, output modifiers (`(re)`, `(glob)`, `(no-eol)`, `(esc)`), exit codes,
+and prose comments.
+
+The mode activates automatically for `.t` files. Use `dune promote` (available
+via `C-c C-d p` with `neocaml-dune-interaction-mode`) to accept corrected test
+output.
+
+> [!NOTE]
+> The `.t` extension is also used by Perl test files. If you work with
+> both OCaml and Perl, you may need to override the association for Perl
+> projects:
+>
+> ```emacs-lisp
+> ;; Use cperl-mode for .t files in Perl projects
+> (add-to-list 'auto-mode-alist '("/t/.*\\.t\\'" . cperl-mode))
+> ```
+>
+> Entries added later to `auto-mode-alist` take priority, so the more specific
+> pattern above will win for `.t` files under a `t/` directory (Perl convention).
+
 ## Comparison with Other Modes
 
 People love comparisons, so here's a comparison of neocaml with its main historical
@@ -625,6 +650,7 @@ alternatives.
 | dune file support          | Yes                        | No            | No           |
 | OCamllex support           | Yes (with OCaml injection) | No            | Yes          |
 | Menhir support             | Yes (with OCaml injection) | No            | Yes          |
+| Cram test support          | Yes                        | No            | No           |
 | Code templates / skeletons | No                         | Yes           | Yes          |
 
 Keep in mind also that `tuareg` uses `caml-mode` internally for some functionality.

--- a/neocaml-cram.el
+++ b/neocaml-cram.el
@@ -1,0 +1,117 @@
+;;; neocaml-cram.el --- Major mode for cram test files -*- lexical-binding: t; -*-
+
+;; Copyright © 2025-2026 Bozhidar Batsov
+;;
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
+;; URL: http://github.com/bbatsov/neocaml
+;; Keywords: languages ocaml cram
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Major mode for editing cram test (.t) files, as used by dune's
+;; expect-test framework.  Cram tests are a simple line-oriented
+;; format where shell commands, expected output, and prose are
+;; distinguished by their indentation:
+;;
+;;   Prose/comments (unindented lines)
+;;
+;;     $ shell-command
+;;     expected output
+;;     > continuation-of-previous-command
+;;
+;; This mode provides font-lock highlighting for all line types,
+;; output modifiers ((re), (glob), (no-eol), (esc)), and dune's
+;; unreachable marker.
+
+;;; License:
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Code:
+
+(defgroup neocaml-cram nil
+  "Major mode for editing cram test files."
+  :prefix "neocaml-cram-"
+  :group 'languages
+  :link '(url-link :tag "GitHub" "https://github.com/bbatsov/neocaml"))
+
+;;; Font-lock
+
+(defvar neocaml-cram--font-lock-keywords
+  `(;; Command lines: "  $ command..."
+    ("^  \\(\\$\\) \\(.*\\)$"
+     (1 'font-lock-keyword-face)
+     (2 'font-lock-function-call-face))
+    ;; Continuation lines: "  > command..."
+    ("^  \\(>\\) \\(.*\\)$"
+     (1 'font-lock-keyword-face)
+     (2 'font-lock-function-call-face))
+    ;; Dune unreachable marker
+    ("^  \\(\\*\\*\\*\\*\\* UNREACHABLE \\*\\*\\*\\*\\*\\)$"
+     (1 'font-lock-warning-face))
+    ;; Output with modifier: "  output (re)" etc.
+    ("^  \\(.*\\) \\((\\(?:re\\|glob\\|no-eol\\|esc\\))\\)$"
+     (1 'font-lock-string-face)
+     (2 'font-lock-type-face))
+    ;; Exit code: "  [N]"
+    ("^  \\(\\[[0-9]+\\]\\)$"
+     (1 'font-lock-constant-face))
+    ;; Plain output lines: "  anything"
+    ("^  \\(.*\\)$"
+     (1 'font-lock-string-face))
+    ;; Prose/comment lines (unindented)
+    ("^\\([^ \n].*\\)$"
+     (1 'font-lock-comment-face)))
+  "Font-lock keywords for `neocaml-cram-mode'.")
+
+;;; Imenu
+
+(defvar neocaml-cram--imenu-generic-expression
+  '(("Command" "^  \\$ \\(.+\\)$" 1))
+  "Imenu generic expression for `neocaml-cram-mode'.
+Indexes shell command lines.")
+
+;;; Mode definition
+
+;;;###autoload
+(define-derived-mode neocaml-cram-mode text-mode "Cram"
+  "Major mode for editing cram test files.
+
+Cram tests use a simple line-oriented format:
+- Lines starting with `  $ ' are shell commands
+- Lines starting with `  > ' are command continuations
+- Lines starting with `  ' (2 spaces) are expected output
+- Unindented lines are prose/comments
+
+\\{neocaml-cram-mode-map}"
+  (setq-local font-lock-defaults '(neocaml-cram--font-lock-keywords))
+  (setq-local font-lock-multiline nil)
+  (setq-local comment-start "")
+  (setq-local comment-end "")
+  (setq-local imenu-generic-expression neocaml-cram--imenu-generic-expression)
+  (setq-local indent-tabs-mode nil)
+  (setq-local tab-width 2)
+  (setq-local require-final-newline mode-require-final-newline))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.t\\'" . neocaml-cram-mode))
+
+(provide 'neocaml-cram)
+
+;;; neocaml-cram.el ends here

--- a/test/neocaml-cram-test.el
+++ b/test/neocaml-cram-test.el
@@ -1,0 +1,104 @@
+;;; neocaml-cram-test.el --- Tests for neocaml-cram-mode -*- lexical-binding: t; -*-
+
+;; Copyright © 2025-2026 Bozhidar Batsov
+
+;;; Commentary:
+
+;; Buttercup tests for neocaml-cram-mode font-lock.
+
+;;; Code:
+
+(require 'neocaml-cram)
+
+(defun neocaml-cram-test--face-at (content substring)
+  "Return the face applied to SUBSTRING in CONTENT after font-locking.
+CONTENT is inserted into a temp buffer with `neocaml-cram-mode'."
+  (with-temp-buffer
+    (insert content)
+    (neocaml-cram-mode)
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward substring)
+    (get-text-property (match-beginning 0) 'face)))
+
+(describe "neocaml-cram font-lock"
+  (describe "command lines"
+    (it "highlights the $ prompt as keyword"
+      (expect (neocaml-cram-test--face-at "  $ echo hello\n" "$")
+              :to-equal 'font-lock-keyword-face))
+
+    (it "highlights the command text"
+      (expect (neocaml-cram-test--face-at "  $ echo hello\n" "echo hello")
+              :to-equal 'font-lock-function-call-face)))
+
+  (describe "continuation lines"
+    (it "highlights the > prompt as keyword"
+      (expect (neocaml-cram-test--face-at "  $ echo \\\n  > hello\n" ">")
+              :to-equal 'font-lock-keyword-face))
+
+    (it "highlights the continuation text"
+      (expect (neocaml-cram-test--face-at "  $ echo \\\n  > hello\n" "hello")
+              :to-equal 'font-lock-function-call-face)))
+
+  (describe "output lines"
+    (it "highlights plain output as string"
+      (expect (neocaml-cram-test--face-at "  $ echo hi\n  hello\n" "hello")
+              :to-equal 'font-lock-string-face))
+
+    (it "highlights output with (re) modifier"
+      (expect (neocaml-cram-test--face-at "  $ echo foo\n  .* (re)\n" "(re)")
+              :to-equal 'font-lock-type-face))
+
+    (it "highlights output with (glob) modifier"
+      (expect (neocaml-cram-test--face-at "  $ echo foo\n  f* (glob)\n" "(glob)")
+              :to-equal 'font-lock-type-face))
+
+    (it "highlights output with (no-eol) modifier"
+      (expect (neocaml-cram-test--face-at "  $ printf x\n  x (no-eol)\n" "(no-eol)")
+              :to-equal 'font-lock-type-face))
+
+    (it "highlights output with (esc) modifier"
+      (expect (neocaml-cram-test--face-at "  $ printf '\\0'\n  \\x00 (esc)\n" "(esc)")
+              :to-equal 'font-lock-type-face)))
+
+  (describe "exit codes"
+    (it "highlights exit codes as constants"
+      (expect (neocaml-cram-test--face-at "  $ exit 1\n  [1]\n" "[1]")
+              :to-equal 'font-lock-constant-face)))
+
+  (describe "unreachable marker"
+    (it "highlights as warning"
+      (expect (neocaml-cram-test--face-at "  ***** UNREACHABLE *****\n"
+                                          "UNREACHABLE")
+              :to-equal 'font-lock-warning-face)))
+
+  (describe "prose/comments"
+    (it "highlights unindented lines as comments"
+      (expect (neocaml-cram-test--face-at "Some prose here\n\n  $ echo hi\n"
+                                          "Some prose here")
+              :to-equal 'font-lock-comment-face)))
+
+  (describe "unknown modifiers"
+    (it "does not highlight unknown modifiers specially"
+      (expect (neocaml-cram-test--face-at "  $ echo\n  output (unknown)\n" "(unknown)")
+              :to-equal 'font-lock-string-face))))
+
+(describe "neocaml-cram imenu"
+  (it "indexes command lines"
+    (with-temp-buffer
+      (require 'imenu)
+      (insert "Prose\n\n  $ echo hello\n  hello\n\n  $ cat file.ml\n  let x = 1\n")
+      (neocaml-cram-mode)
+      (let ((index (funcall imenu-create-index-function)))
+        (expect (length index) :to-equal 1)
+        (let ((commands (cdr (assoc "Command" index))))
+          (expect (length commands) :to-equal 2)
+          (expect (caar commands) :to-equal "echo hello")
+          (expect (caadr commands) :to-equal "cat file.ml"))))))
+
+(describe "neocaml-cram auto-mode"
+  (it "associates .t files with neocaml-cram-mode"
+    (expect (cdr (assoc "\\.t\\'" auto-mode-alist))
+            :to-equal 'neocaml-cram-mode)))
+
+;;; neocaml-cram-test.el ends here

--- a/test/resources/sample.t
+++ b/test/resources/sample.t
@@ -1,0 +1,85 @@
+Basic commands and output:
+
+  $ echo hello
+  hello
+
+  $ echo "multi-word output"
+  multi-word output
+
+  $ cat <<EOF
+  > line one
+  > line two
+  > EOF
+  line one
+  line two
+
+Multi-line commands with backslash continuation:
+
+  $ echo \
+  >   hello \
+  >   world
+  hello world
+
+Output modifiers:
+
+  $ date
+  .* (re)
+
+  $ ls *.ml
+  f* (glob)
+
+  $ printf "no newline"
+  no newline (no-eol)
+
+  $ printf "\x00binary"
+  \x00binary (esc)
+
+Non-zero exit codes:
+
+  $ false
+  [1]
+
+  $ exit 42
+  [42]
+
+Multiple lines of output:
+
+  $ seq 1 5
+  1
+  2
+  3
+  4
+  5
+
+Empty command (just a prompt):
+
+  $
+
+Dune-typical patterns:
+
+  $ cat > foo.ml <<EOF
+  > let () = print_endline "hello"
+  > EOF
+
+  $ ocamlfind ocamlc -package str foo.ml -linkpkg -o foo 2>&1
+  File "foo.ml", line 3, characters 5-8:
+  Error: Unbound value bar
+  [2]
+
+Unreachable commands after early exit:
+
+  $ exit 1
+  [1]
+  ***** UNREACHABLE *****
+  $ echo "this never runs"
+
+A test with mixed prose and commands showing realistic dune workflow:
+
+  $ dune build 2>&1
+  $ dune exec ./main.exe
+  Hello, world!
+
+  $ dune exec ./main.exe -- --verbose
+  [DEBUG] Starting up
+  Hello, world!
+  [DEBUG] Shutting down


### PR DESCRIPTION
Adds a regexp-based major mode for dune's cram test (.t) files with font-lock for shell commands, continuations, expected output, output modifiers (re/glob/no-eol/esc), exit codes, unreachable markers, and prose. Includes imenu support for navigating between commands.