### PR TITLE
Register .ocamlinit and .ocamlformat file associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,13 @@ output.
 > Entries added later to `auto-mode-alist` take priority, so the more specific
 > pattern above will win for `.t` files under a `t/` directory (Perl convention).
 
+### Other OCaml-related Files
+
+neocaml also registers sensible modes for a few other OCaml-related files:
+
+- `.ocamlinit` opens in `neocaml-mode` (it's OCaml toplevel startup code)
+- `.ocamlformat` and `.ocp-indent` open in `conf-unix-mode` (key = value config files with `#` comments)
+
 ## Comparison with Other Modes
 
 People love comparisons, so here's a comparison of neocaml with its main historical

--- a/neocaml.el
+++ b/neocaml.el
@@ -1329,8 +1329,14 @@ for .ml files and `neocaml-interface-mode' for .mli files."
 
 ;;;###autoload
 (progn
+  ;; OCaml source files
   (add-to-list 'auto-mode-alist '("\\.ml\\'" . neocaml-mode))
-  (add-to-list 'auto-mode-alist '("\\.mli\\'" . neocaml-interface-mode)))
+  (add-to-list 'auto-mode-alist '("\\.mli\\'" . neocaml-interface-mode))
+  ;; OCaml toplevel init file (plain OCaml code)
+  (add-to-list 'auto-mode-alist '("\\.ocamlinit\\'" . neocaml-mode))
+  ;; OCaml config files (key = value format with # comments)
+  (add-to-list 'auto-mode-alist '("/\\.ocamlformat\\'" . conf-unix-mode))
+  (add-to-list 'auto-mode-alist '("/\\.ocp-indent\\'" . conf-unix-mode)))
 
 ;; Hide OCaml build artifacts from find-file completion
 (dolist (ext '(".cmo" ".cmx" ".cma" ".cmxa" ".cmi" ".annot" ".cmt" ".cmti"))


### PR DESCRIPTION
Opens .ocamlinit files in neocaml-mode (they're OCaml toplevel startup scripts) and .ocamlformat files in conf-mode (key=value format with # comments).