### PR TITLE
Extend Opam regex to cover template files.

### DIFF
--- a/neocaml-opam.el
+++ b/neocaml-opam.el
@@ -311,9 +311,10 @@ tree-sitter >= 0.25.0" (treesit-library-abi-version)))
               #'neocaml-opam--flymake-lint nil t)))
 
 ;;;###autoload
-;; Matches both bare "opam" files (e.g., repo/opam) and named
-;; "foo.opam" files — the [./] covers the dot in ".opam".
-(add-to-list 'auto-mode-alist '("[./]opam\\'" . neocaml-opam-mode))
+;; Matches bare "opam" files (e.g., repo/opam), named "foo.opam"
+;; files, — the [./] covers the dot in ".opam".
+;; Optionally matches "foo.opam.template" files.
+(add-to-list 'auto-mode-alist '("[./]opam\\(?:\\.template\\)?\\'" . neocaml-opam-mode))
 
 (provide 'neocaml-opam)
 

--- a/test/neocaml-opam-test.el
+++ b/test/neocaml-opam-test.el
@@ -235,4 +235,26 @@ of the example package.
       (expect (neocaml-opam--parse-lint-line "Passed." (current-buffer))
               :to-be nil))))
 
+(describe "neocaml-opam auto-mode"
+  (it "matches foo.opam"
+    (let ((match (assoc "foo.opam" auto-mode-alist #'string-match-p)))
+      (expect match :to-be-truthy)
+      (expect (cdr match) :to-equal 'neocaml-opam-mode)))
+
+  (it "matches bare /opam"
+    (let ((match (assoc "/opam" auto-mode-alist #'string-match-p)))
+      (expect match :to-be-truthy)
+      (expect (cdr match) :to-equal 'neocaml-opam-mode)))
+
+  (it "matches foo.opam.template"
+    (let ((match (assoc "foo.opam.template" auto-mode-alist #'string-match-p)))
+      (expect match :to-be-truthy)
+      (expect (cdr match) :to-equal 'neocaml-opam-mode)))
+
+  (it "does not match foo.opam.lock"
+    (let ((match (assoc "foo.opam.lock" auto-mode-alist #'string-match-p)))
+      (expect (or (null match)
+                  (not (eq (cdr match) 'neocaml-opam-mode)))
+              :to-be-truthy))))
+
 ;;; neocaml-opam-test.el ends here


### PR DESCRIPTION
In OCaml it's very common to have a `project.opam` file and a `project.opam.template` file when you generate the opam file from a dune-project file. Some fields in an opam file aren't supported in the generation process and you need to override them. This change extends the regex to cover the template files plus tests to check the regex.