### PR TITLE
Make _build/ directory redirect optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ One last thing - we really need more Emacs packages with fun names! :D
 - Cram test file editing (`neocaml-cram-mode`) with font-lock for commands, output, modifiers, and prose
 - Easy installation of `ocaml` and `ocaml-interface` tree-sitter grammars via `M-x neocaml-install-grammars`
 - Compilation error regexp for `M-x compile` (errors, warnings, alerts, backtraces)
-- `_build` directory awareness (offers to switch to source when opening build artifacts)
+- `_build` directory awareness (offers to switch to source when opening build artifacts, configurable via `neocaml-redirect-build-files`)
 - Eglot integration (with [ocaml-eglot](https://github.com/tarides/ocaml-eglot) support)
 - Debugging via [dape](https://github.com/svaante/dape) + [ocamlearlybird](https://github.com/hackwaly/ocamlearlybird) (bytecode)
 - Prettify-symbols for common OCaml operators
@@ -690,6 +690,12 @@ Once the session starts, dape provides the standard debugging commands:
   `dune-project` for breakpoints to resolve correctly.
 - See the [ocamlearlybird documentation](https://github.com/hackwaly/ocamlearlybird)
   for troubleshooting and known limitations.
+- neocaml normally offers to redirect you away from `_build/` files. If this
+  interferes with your debugging workflow, disable it:
+
+  ```emacs-lisp
+  (setq neocaml-redirect-build-files nil)
+  ```
 
 ## Comparison with Other Modes
 

--- a/neocaml.el
+++ b/neocaml.el
@@ -99,6 +99,14 @@ The extra symbols may affect column alignment."
   :group 'neocaml
   :package-version '(neocaml . "0.2.0"))
 
+(defcustom neocaml-redirect-build-files t
+  "When non-nil, offer to switch to the source file when opening a file under `_build/'.
+Set to nil if you work with build artifacts directly, e.g. when debugging."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'neocaml
+  :package-version '(neocaml . "0.8.0"))
+
 (defvar neocaml--debug nil
   "Enable debugging messages and show the current node in the mode-line.
 When set to t, show indentation debug info.
@@ -996,7 +1004,8 @@ does not exist."
   "If the current file is under `_build/', offer to switch to the source.
 Intended for use in `find-file-hook'."
   (when-let* ((file (buffer-file-name)))
-    (when (and (derived-mode-p 'neocaml-base-mode)
+    (when (and neocaml-redirect-build-files
+               (derived-mode-p 'neocaml-base-mode)
                (string-match-p "/_build/" file))
       (if-let* ((source (neocaml--resolve-build-path file)))
           (when (y-or-n-p (format "This file is under _build.  Switch to %s? " source))

--- a/test/neocaml-build-test.el
+++ b/test/neocaml-build-test.el
@@ -38,4 +38,51 @@
       (expect (neocaml--resolve-build-path "/project/_build/default/lib/foo.ml")
               :to-equal "/project/lib/foo.ml"))))
 
+(describe "neocaml-redirect-build-files"
+  (it "defaults to t"
+    (expect (default-value 'neocaml-redirect-build-files) :to-be t))
+
+  (it "is declared safe for directory-local use"
+    (expect (get 'neocaml-redirect-build-files 'safe-local-variable)
+            :to-equal #'booleanp)))
+
+(describe "neocaml--check-build-dir"
+  (it "prompts to switch when visiting a _build/ file"
+    (let ((prompted nil))
+      (cl-letf (((symbol-function 'buffer-file-name)
+                 (lambda () "/project/_build/default/lib/foo.ml"))
+                ((symbol-function 'derived-mode-p)
+                 (lambda (&rest _) t))
+                ((symbol-function 'file-readable-p)
+                 (lambda (f) (string= f "/project/lib/foo.ml")))
+                ((symbol-function 'y-or-n-p)
+                 (lambda (_prompt) (setq prompted t) nil)))
+        (let ((neocaml-redirect-build-files t))
+          (neocaml--check-build-dir)
+          (expect prompted :to-be t)))))
+
+  (it "does not prompt when neocaml-redirect-build-files is nil"
+    (let ((prompted nil))
+      (cl-letf (((symbol-function 'buffer-file-name)
+                 (lambda () "/project/_build/default/lib/foo.ml"))
+                ((symbol-function 'derived-mode-p)
+                 (lambda (&rest _) t))
+                ((symbol-function 'y-or-n-p)
+                 (lambda (_prompt) (setq prompted t) nil)))
+        (let ((neocaml-redirect-build-files nil))
+          (neocaml--check-build-dir)
+          (expect prompted :to-be nil)))))
+
+  (it "does not prompt for non-_build/ files"
+    (let ((prompted nil))
+      (cl-letf (((symbol-function 'buffer-file-name)
+                 (lambda () "/project/lib/foo.ml"))
+                ((symbol-function 'derived-mode-p)
+                 (lambda (&rest _) t))
+                ((symbol-function 'y-or-n-p)
+                 (lambda (_prompt) (setq prompted t) nil)))
+        (let ((neocaml-redirect-build-files t))
+          (neocaml--check-build-dir)
+          (expect prompted :to-be nil))))))
+
 ;;; neocaml-build-test.el ends here


### PR DESCRIPTION
Adds `neocaml-check-build-dir` (default t) so users can disable the prompt to switch away from `_build/` files. Useful when debugging with ocamlearlybird or intentionally working with build artifacts.