### PR TITLE
Add neocaml support for odoc mld files.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           eldev eval '(progn (load "neocaml-dune") (neocaml-dune-install-grammar))'
           eldev eval '(progn (load "neocaml-ocamllex") (neocaml-ocamllex-install-grammar))'
           eldev eval '(progn (load "neocaml-menhir") (neocaml-menhir-install-grammar))'
+          eldev eval '(progn (load "neocaml-odoc") (neocaml-odoc-install-grammar))'
 
       - run: eldev byte-compile --warnings-as-errors
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           eldev eval '(progn (load "neocaml-dune") (neocaml-dune-install-grammar))'
           eldev eval '(progn (load "neocaml-ocamllex") (neocaml-ocamllex-install-grammar))'
           eldev eval '(progn (load "neocaml-menhir") (neocaml-menhir-install-grammar))'
+          eldev eval '(progn (load "neocaml-odoc") (neocaml-odoc-install-grammar))'
 
       - run: eldev byte-compile --warnings-as-errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - [#60](https://github.com/bbatsov/neocaml/issues/60): Render ocamldoc markup in doc comments - `{b bold}`, `{i italic}`, `[code]`, `{[...]}` code blocks, `{!references}` and `@tags` are now displayed with real faces via the new `doc-markup` font-lock feature (enabled at the default font-lock level).
 
+- [#46](https://github.com/bbatsov/neocaml/pull/46): New `neocaml-odoc-mode` for [odoc](https://ocaml.github.io/odoc/) documentation pages (`.mld`), with font-lock for headings, inline markup, code spans, references, links, tags, lists and tables, indentation, imenu, and language injection into `{@lang[...]}` code blocks for OCaml, dune and opam (Emacs 30+). Install its grammar with `M-x neocaml-odoc-install-grammar`.
+
 ### Changes
 
 - [#80](https://github.com/bbatsov/neocaml/pull/80): Use the hybrid forward-sexp function on every Emacs version, so `C-M-f` moves over whole keyword-led forms (`fun`, `match`, `if`, etc.) on Emacs 31+ instead of stopping after the keyword.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ ecosystem: [dune](https://dune.build) build files,
 [opam](https://opam.ocaml.org) package definitions,
 [OCamllex](https://v2.ocaml.org/manual/lexyacc.html) lexer definitions (`.mll`),
 [Menhir](http://gallium.inria.fr/~fpottier/menhir/) parser definitions (`.mly`),
-and [cram](https://dune.readthedocs.io/en/stable/tests.html#cram-tests) test
-files (`.t`), each with a dedicated major mode.
+[cram](https://dune.readthedocs.io/en/stable/tests.html#cram-tests) test files
+(`.t`), and [odoc](https://ocaml.github.io/odoc/) documentation pages (`.mld`),
+each with a dedicated major mode.
 
 You can also view compiled OCaml artifacts (`.cmi`, `.cmo`, `.cmx`, etc.)
 directly in Emacs via `ocamlobjinfo`.
@@ -45,6 +46,7 @@ It's also as cool as Neo from "The Matrix". ;-)
 - OCamllex file editing (`neocaml-ocamllex-mode`) with font-lock, indentation, imenu, and OCaml language injection (Emacs 30+)
 - Menhir file editing (`neocaml-menhir-mode`) with font-lock, indentation, imenu, and OCaml language injection (Emacs 30+)
 - Cram test file editing (`neocaml-cram-mode`) with font-lock for commands, output, modifiers, and prose
+- odoc documentation editing (`neocaml-odoc-mode`) with font-lock, indentation, imenu, and language injection into `{@lang[...]}` code blocks for OCaml, dune, and opam (Emacs 30+)
 - Easy installation of `ocaml` and `ocaml-interface` tree-sitter grammars via `M-x neocaml-install-grammars`
 - Compilation error regexp for `M-x compile` (errors, warnings, alerts, backtraces)
 - `_build` directory awareness (offers to switch to source when opening build artifacts)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,14 +13,15 @@ are only available on newer versions:
   thing (on earlier versions, neocaml provides `neocaml-backward-up-list`
   as a workaround)
 
-## How do I install grammars for dune, opam, OCamllex, or Menhir?
+## How do I install grammars for dune, opam, OCamllex, Menhir, or odoc?
 
 `M-x neocaml-install-grammars` only installs the OCaml and
 OCaml-interface grammars. The other modes have their own grammar
 install commands: `M-x neocaml-dune-install-grammar`,
 `M-x neocaml-opam-install-grammar`,
-`M-x neocaml-ocamllex-install-grammar`, and
-`M-x neocaml-menhir-install-grammar`. Each mode will also prompt
+`M-x neocaml-ocamllex-install-grammar`,
+`M-x neocaml-menhir-install-grammar`, and
+`M-x neocaml-odoc-install-grammar`. Each mode will also prompt
 you to install its grammar on first use.
 
 ## Can I use Merlin instead of Eglot?

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,8 +15,9 @@ ecosystem: [dune](https://dune.build) build files,
 [opam](https://opam.ocaml.org) package definitions,
 [OCamllex](https://v2.ocaml.org/manual/lexyacc.html) lexer definitions (`.mll`),
 [Menhir](http://gallium.inria.fr/~fpottier/menhir/) parser definitions (`.mly`),
-and [cram](https://dune.readthedocs.io/en/stable/tests.html#cram-tests) test
-files (`.t`) -- each with a dedicated major mode.
+[cram](https://dune.readthedocs.io/en/stable/tests.html#cram-tests) test files
+(`.t`), and [odoc](https://ocaml.github.io/odoc/) documentation pages (`.mld`)
+-- each with a dedicated major mode.
 
 You can also view compiled OCaml artifacts (`.cmi`, `.cmo`, `.cmx`, etc.)
 directly in Emacs via `ocamlobjinfo`.
@@ -59,6 +60,7 @@ One last thing - we really need more Emacs packages with fun names! :D
 - OCamllex file editing (`neocaml-ocamllex-mode`) with font-lock, indentation, imenu, and OCaml language injection (Emacs 30+)
 - Menhir file editing (`neocaml-menhir-mode`) with font-lock, indentation, imenu, and OCaml language injection (Emacs 30+)
 - Cram test file editing (`neocaml-cram-mode`) with font-lock for commands, output, modifiers, and prose
+- odoc documentation editing (`neocaml-odoc-mode`) with font-lock, indentation, imenu, and language injection into `{@lang[...]}` code blocks for OCaml, dune, and opam (Emacs 30+)
 - Easy installation of `ocaml` and `ocaml-interface` tree-sitter grammars via `M-x neocaml-install-grammars`
 - Compilation error regexp for `M-x compile` (errors, warnings, alerts, backtraces)
 - `_build` directory awareness (offers to switch to source when opening build artifacts, configurable via `neocaml-redirect-build-files`)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,13 +33,14 @@ Or with `use-package` on Emacs 30+:
     OCaml-interface grammars. If grammar installation fails, see
     [Troubleshooting](troubleshooting.md#tree-sitter-abi-version-mismatch).
 
-    The modes for dune, opam, OCamllex, and Menhir files each use
-    their own grammar. These are installed automatically when you
+    The modes for dune, opam, OCamllex, Menhir, and odoc files each
+    use their own grammar. These are installed automatically when you
     first open a file of that type, or you can install them manually
     with `M-x neocaml-dune-install-grammar`,
     `M-x neocaml-opam-install-grammar`,
-    `M-x neocaml-ocamllex-install-grammar`, and
-    `M-x neocaml-menhir-install-grammar`.
+    `M-x neocaml-ocamllex-install-grammar`,
+    `M-x neocaml-menhir-install-grammar`, and
+    `M-x neocaml-odoc-install-grammar`.
 
 !!! tip
     If you have another OCaml major mode installed (e.g. `tuareg` or `caml-mode`),

--- a/docs/odoc.md
+++ b/docs/odoc.md
@@ -1,0 +1,88 @@
+# odoc Support
+
+neocaml includes a dedicated tree-sitter mode for
+[odoc](https://ocaml.github.io/odoc/) documentation pages.
+`neocaml-odoc-mode` activates automatically for `.mld` files and
+provides font-lock, indentation, imenu, and language injection into
+code blocks.
+
+## Grammar Installation
+
+The mode requires its own tree-sitter grammar, separate from the main
+OCaml grammars. It will prompt you to install the grammar on first
+use, or you can install it manually:
+
+    M-x neocaml-odoc-install-grammar
+
+With a prefix argument (`C-u`), the command reinstalls even if the
+grammar is already present.
+
+!!! note
+    The odoc grammar requires tree-sitter ABI version 14+
+    (tree-sitter >= 0.24). If your Emacs was built against an
+    older tree-sitter, you may need to update it. See
+    [Troubleshooting](troubleshooting.md) for details.
+
+## Font-lock
+
+Every odoc construct gets its own face, so you can remap any of them
+without disturbing the others:
+
+| Face | Markup |
+|------|--------|
+| `neocaml-odoc-heading-face` | `{0 Title}` through `{5 ...}` |
+| `neocaml-odoc-bold-face` | `{b ...}` |
+| `neocaml-odoc-italic-face` | `{i ...}` |
+| `neocaml-odoc-emphasis-face` | `{e ...}` |
+| `neocaml-odoc-tag-face` | `@param`, `@return`, `@since`, ... |
+| `neocaml-odoc-tag-name-face` | the name in `@param name` and `@raise Exn` |
+| `neocaml-odoc-tag-value-face` | the version in `@before 1.0` |
+| `neocaml-odoc-code-face` | `[inline code]` and code blocks |
+| `neocaml-odoc-verbatim-face` | `{v ... v}` |
+| `neocaml-odoc-language-face` | the language tag of `{@ocaml[...]}` |
+| `neocaml-odoc-math-face` | `{m ...}` and `{math ...}` |
+| `neocaml-odoc-reference-face` | `{!Module.value}` |
+| `neocaml-odoc-link-face` | `{:https://...}` and media targets |
+| `neocaml-odoc-escape-face` | `\{`, `\}`, `\[`, `\]`, `\@` |
+| `neocaml-odoc-markup-face` | `{^ ...}`, `{_ ...}` |
+| `neocaml-odoc-raw-markup-face` | `{%html: ...%}` |
+| `neocaml-odoc-list-face` | `{ul ...}`, `{ol ...}` |
+| `neocaml-odoc-bracket-face` | the delimiters themselves |
+
+Bracket highlighting is a level-4 feature, so raise
+`treesit-font-lock-level` to 4 if you want the delimiters coloured.
+
+## Language Injection
+
+On Emacs 30+, code inside a `{@lang[...]}` block gets full syntax
+highlighting for that language:
+
+    {@ocaml[
+    let greet name = Printf.printf "Hello, %s!\n" name
+    ]}
+
+OCaml, dune, and opam are injected, each when its grammar is
+installed; delimited blocks such as `{delim@ocaml[...]delim}` are
+injected too. A block in any other language still reads as code, via
+`neocaml-odoc-code-face`.
+
+Language injection activates automatically. No configuration is
+needed.
+
+## Imenu
+
+Imenu indexes the page under two categories:
+
+- **Heading**: every `{0 ...}` through `{5 ...}`, named by its title
+- **Tag**: `@param`, `@return`, `@raise`, `@deprecated`, `@since`,
+  `@version` and `@author`
+
+Headings also act as defuns, so `C-M-a` and `C-M-e` move between
+sections.
+
+## Configuration
+
+```emacs-lisp
+;; odoc indentation (default: 2)
+(setq neocaml-odoc-indent-offset 4)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
     - REPL Integration: repl.md
     - opam, dune & Cram: opam_and_dune.md
     - OCamllex & Menhir: ocamllex_and_menhir.md
+    - odoc: odoc.md
     - Compiled Artifacts: objinfo.md
     - Debugging: debugging.md
   - Migration: migration.md

--- a/neocaml-odoc.el
+++ b/neocaml-odoc.el
@@ -108,6 +108,7 @@ With prefix argument FORCE, reinstall even if already installed."
 
    :language 'odoc
    :feature 'tag
+   :override t
    '((param_name) @font-lock-variable-name-face
      (raise_name) @font-lock-variable-name-face
      (before_version) @font-lock-constant-face)
@@ -156,7 +157,7 @@ With prefix argument FORCE, reinstall even if already installed."
 
    :language 'odoc
    :feature 'bracket
-   '(["[" "]" "]}" "{" "}" "{b" "{i" "{e" "{^" "{_"
+   '(["[" "]" "]}" "}" "{b" "{i" "{e" "{^" "{_"
       "{!" "{{!" "{:" "{{:" "{%" "{m" "{math"
       "{[" "{v" "{ul" "{ol" "{li" "{table" "{tr" "{th" "{td" "{t"
       "{L" "{C" "{R" "{!modules:" "%}"]
@@ -199,6 +200,7 @@ Requires Emacs 30+ for `treesit-range-rules' with `:embed'."
      (symbol-value 'neocaml-opam--font-lock-settings))
     ('bash
      ;; Emacs built-in bash-ts-mode font-lock; not easily extractable.
+     ;; TODO Use sh-mode--treesit-settings?
      nil)))
 
 (defun neocaml-odoc--font-lock-settings ()

--- a/neocaml-odoc.el
+++ b/neocaml-odoc.el
@@ -310,6 +310,10 @@ injection.  See `neocaml-odoc--injection-language-alist' for
 supported languages.
 
 \\{neocaml-odoc-mode-map}"
+  (when (< (treesit-library-abi-version) 14)
+    (error "The odoc grammar requires tree-sitter ABI version 14+, but \
+your Emacs was built against ABI version %d; rebuild Emacs with \
+tree-sitter >= 0.22.0" (treesit-library-abi-version)))
   (unless (treesit-ready-p 'odoc)
     (when (y-or-n-p "Odoc tree-sitter grammar is not installed.  Install it now?")
       (neocaml-odoc-install-grammar))

--- a/neocaml-odoc.el
+++ b/neocaml-odoc.el
@@ -198,11 +198,7 @@ Requires Emacs 30+ for `treesit-range-rules' with `:embed'."
      neocaml-dune--font-lock-settings)
     ('opam
      (require 'neocaml-opam)
-     neocaml-opam--font-lock-settings)
-    ('bash
-     ;; Emacs built-in bash-ts-mode font-lock; not easily extractable.
-     ;; TODO Use sh-mode--treesit-settings?
-     nil)))
+     neocaml-opam--font-lock-settings)))
 
 (defun neocaml-odoc--font-lock-settings ()
   "Return font-lock settings for `neocaml-odoc-mode'.
@@ -329,15 +325,17 @@ tree-sitter >= 0.22.0" (treesit-library-abi-version)))
   ;; Font-lock
   (setq-local treesit-font-lock-settings (neocaml-odoc--font-lock-settings))
   (setq-local treesit-font-lock-feature-list
-              '((heading tag)
-                (markup code math)
-                (reference escape-sequence)
+              '(( heading tag
+                  ;; Injected grammar features — levels mirror those used
+                  ;; by `neocaml-mode', `neocaml-dune-mode', etc. so that
+                  ;; embedded code gets highlighted at the default level.
+                  comment definition keyword)
+                (markup code math
+                 string type property)
+                (reference escape-sequence
+                 attribute builtin constant number)
                 (list bracket
-                 ;; Injection-dependent features (active when grammars installed)
-                 ;; TODO Can we trim this list of features?
-                 comment definition keyword string type constant
-                 attribute builtin number variable operator
-                 delimiter property label function)))
+                 variable operator delimiter label function)))
 
   ;; Indentation
   (setq-local treesit-simple-indent-rules neocaml-odoc--indent-rules)

--- a/neocaml-odoc.el
+++ b/neocaml-odoc.el
@@ -82,79 +82,189 @@ With prefix argument FORCE, reinstall even if already installed."
     (let ((treesit-language-source-alist neocaml-odoc-grammar-recipes))
       (treesit-install-language-grammar 'odoc))))
 
+;;; Faces
+
+(defface neocaml-odoc-heading-face
+  '((t :inherit font-lock-function-name-face :weight bold))
+  "Face for odoc section headings."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-bold-face
+  '((t :inherit bold))
+  "Face for bold markup in odoc."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-italic-face
+  '((t :inherit italic))
+  "Face for italic markup in odoc."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-emphasis-face
+  '((t :inherit bold-italic))
+  "Face for emphasis markup in odoc."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-tag-face
+  '((t :inherit font-lock-keyword-face))
+  "Face for documentation tags (@param, @return, etc.)."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-tag-name-face
+  '((t :inherit font-lock-variable-name-face))
+  "Face for parameter and exception names in tags."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-tag-value-face
+  '((t :inherit font-lock-constant-face))
+  "Face for version strings in tags."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-code-face
+  '((t :inherit (fixed-pitch font-lock-constant-face)))
+  "Face for inline code spans and plain code blocks."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-verbatim-face
+  '((t :inherit (fixed-pitch font-lock-string-face)))
+  "Face for verbatim blocks."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-language-face
+  '((t :inherit font-lock-type-face))
+  "Face for the language tag in code blocks ({@ocaml[...]})."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-math-face
+  '((t :inherit font-lock-string-face))
+  "Face for math spans and blocks."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-reference-face
+  '((t :inherit link))
+  "Face for identifier references ({!Module.foo})."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-link-face
+  '((t :inherit link))
+  "Face for URL links ({:https://...})."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-escape-face
+  '((t :inherit font-lock-escape-face))
+  "Face for escape sequences."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-markup-face
+  '((t :inherit shadow))
+  "Face for structural markup (superscript, subscript delimiters)."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-raw-markup-face
+  '((t :inherit font-lock-preprocessor-face))
+  "Face for raw markup (embedded HTML/LaTeX)."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-list-face
+  '((t :inherit neocaml-odoc-markup-face))
+  "Face for list markup."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
+(defface neocaml-odoc-bracket-face
+  '((t :inherit shadow))
+  "Face for odoc bracket delimiters."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.9.0"))
+
 ;;; Font-lock
 
 (defvar neocaml-odoc--font-lock-settings
   (treesit-font-lock-rules
    :language 'odoc
    :feature 'heading
-   '((heading) @font-lock-function-name-face)
+   '((heading) @neocaml-odoc-heading-face)
 
    :language 'odoc
    :feature 'tag
-   '((tag_author) @font-lock-keyword-face
-     (tag_param) @font-lock-keyword-face
-     (tag_raise) @font-lock-keyword-face
-     (tag_return) @font-lock-keyword-face
-     (tag_see) @font-lock-keyword-face
-     (tag_since) @font-lock-keyword-face
-     (tag_before) @font-lock-keyword-face
-     (tag_version) @font-lock-keyword-face
-     (tag_deprecated) @font-lock-keyword-face
-     (tag_canonical) @font-lock-keyword-face
-     (tag_inline) @font-lock-keyword-face
-     (tag_open) @font-lock-keyword-face
-     (tag_closed) @font-lock-keyword-face
-     (tag_hidden) @font-lock-keyword-face)
+   '((tag_author) @neocaml-odoc-tag-face
+     (tag_param) @neocaml-odoc-tag-face
+     (tag_raise) @neocaml-odoc-tag-face
+     (tag_return) @neocaml-odoc-tag-face
+     (tag_see) @neocaml-odoc-tag-face
+     (tag_since) @neocaml-odoc-tag-face
+     (tag_before) @neocaml-odoc-tag-face
+     (tag_version) @neocaml-odoc-tag-face
+     (tag_deprecated) @neocaml-odoc-tag-face
+     (tag_canonical) @neocaml-odoc-tag-face
+     (tag_inline) @neocaml-odoc-tag-face
+     (tag_open) @neocaml-odoc-tag-face
+     (tag_closed) @neocaml-odoc-tag-face
+     (tag_hidden) @neocaml-odoc-tag-face)
 
    :language 'odoc
    :feature 'tag
    :override t
-   '((param_name) @font-lock-variable-name-face
-     (raise_name) @font-lock-variable-name-face
-     (before_version) @font-lock-constant-face)
+   '((param_name) @neocaml-odoc-tag-name-face
+     (raise_name) @neocaml-odoc-tag-name-face
+     (before_version) @neocaml-odoc-tag-value-face)
 
    :language 'odoc
    :feature 'markup
-   '((bold) @bold
-     (italic) @italic
-     (emphasis) @bold-italic)
+   '((bold) @neocaml-odoc-bold-face
+     (italic) @neocaml-odoc-italic-face
+     (emphasis) @neocaml-odoc-emphasis-face)
 
    :language 'odoc
    :feature 'code
-   '((code_span) @font-lock-string-face
-     (code_block) @font-lock-string-face
-     (code_block_with_lang (language) @font-lock-type-face)
-     (verbatim_block) @font-lock-string-face)
+   '((code_span) @neocaml-odoc-code-face
+     (code_block) @neocaml-odoc-code-face
+     (code_block_with_lang (language) @neocaml-odoc-language-face)
+     (verbatim_block) @neocaml-odoc-verbatim-face)
 
    :language 'odoc
    :feature 'math
-   '((math_span) @font-lock-number-face
-     (math_block) @font-lock-number-face)
+   '((math_span) @neocaml-odoc-math-face
+     (math_block) @neocaml-odoc-math-face)
 
    :language 'odoc
    :feature 'reference
-   '((simple_reference) @font-lock-constant-face
-     (reference_with_text (reference_target) @font-lock-constant-face)
-     (simple_link) @font-lock-constant-face
-     (link_with_text (link_target) @font-lock-constant-face)
-     (module_name) @font-lock-constant-face)
+   '((simple_reference) @neocaml-odoc-reference-face
+     (reference_with_text (reference_target) @neocaml-odoc-reference-face)
+     (simple_link) @neocaml-odoc-link-face
+     (link_with_text (link_target) @neocaml-odoc-link-face)
+     (module_name) @neocaml-odoc-reference-face)
 
    :language 'odoc
    :feature 'escape-sequence
    :override t
-   '((escape_sequence) @font-lock-escape-face)
+   '((escape_sequence) @neocaml-odoc-escape-face)
 
    :language 'odoc
    :feature 'markup
-   '((superscript) @font-lock-doc-markup-face
-     (subscript) @font-lock-doc-markup-face
-     (raw_markup) @font-lock-preprocessor-face)
+   '((superscript) @neocaml-odoc-markup-face
+     (subscript) @neocaml-odoc-markup-face
+     (raw_markup) @neocaml-odoc-raw-markup-face)
 
    :language 'odoc
    :feature 'list
-   '((unordered_list) @font-lock-bracket-face
-     (ordered_list) @font-lock-bracket-face)
+   '((unordered_list) @neocaml-odoc-list-face
+     (ordered_list) @neocaml-odoc-list-face)
 
    :language 'odoc
    :feature 'bracket
@@ -162,7 +272,7 @@ With prefix argument FORCE, reinstall even if already installed."
       "{!" "{{!" "{:" "{{:" "{%" "{m" "{math"
       "{[" "{v" "{ul" "{ol" "{li" "{table" "{tr" "{th" "{td" "{t"
       "{L" "{C" "{R" "{!modules:" "%}"]
-     @font-lock-bracket-face))
+     @neocaml-odoc-bracket-face))
   "Font-lock settings for `neocaml-odoc-mode'.")
 
 (defvar neocaml-odoc--injection-language-alist

--- a/neocaml-odoc.el
+++ b/neocaml-odoc.el
@@ -175,14 +175,14 @@ With prefix argument FORCE, reinstall even if already installed."
 Each entry is (TAG . GRAMMAR) where TAG is the string used in
 `{@tag[...]}' blocks and GRAMMAR is the tree-sitter language symbol.")
 
-(defun neocaml-odoc--injection-capable-p ()
+(defun neocaml-odoc--injection-available-p ()
   "Non-nil if language injection is supported.
 Requires Emacs 30+ for `treesit-range-rules' with `:embed'."
   (>= emacs-major-version 30))
 
 (defun neocaml-odoc--available-injections ()
   "Return the subset of `neocaml-odoc--injection-language-alist' with installed grammars."
-  (when (neocaml-odoc--injection-capable-p)
+  (when (neocaml-odoc--injection-available-p)
     (seq-filter (lambda (entry)
                   (treesit-language-available-p (cdr entry)))
                 neocaml-odoc--injection-language-alist)))
@@ -330,6 +330,7 @@ supported languages.
                 (reference escape-sequence)
                 (list bracket
                  ;; Injection-dependent features (active when grammars installed)
+                 ;; TODO Can we trim this list of features?
                  comment definition keyword string type constant
                  attribute builtin number variable operator
                  delimiter property label function)))

--- a/neocaml-odoc.el
+++ b/neocaml-odoc.el
@@ -2,7 +2,8 @@
 
 ;; Copyright © 2025-2026 Bozhidar Batsov
 ;;
-;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+;; Author: Tim McGilchrist <timmcgil@gmail.com>
+;;         Bozhidar Batsov <bozhidar@batsov.dev>
 ;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
 ;; URL: http://github.com/bbatsov/neocaml
 ;; Keywords: languages ocaml odoc
@@ -15,9 +16,10 @@
 ;; files.  Provides font-lock for the odoc markup language including
 ;; headings, inline formatting (bold, italic, emphasis), code spans,
 ;; references, links, tags, lists, tables, and code blocks.  When the
-;; OCaml tree-sitter grammar is installed, embedded OCaml code inside
-;; {@ocaml[...]} blocks gets full syntax highlighting via language
-;; injection.
+;; relevant tree-sitter grammars are installed, embedded code inside
+;; {@lang[...]} blocks gets full syntax highlighting via language
+;; injection.  Supported languages: OCaml, dune, opam, and
+;; sh/bash.
 ;;
 ;; For the tree-sitter grammar this mode is based on,
 ;; see https://github.com/tmcgilchrist/tree-sitter-odoc.
@@ -41,6 +43,8 @@
 
 ;;; Code:
 
+(require 'cl-lib)
+(require 'map)
 (require 'treesit)
 
 (declare-function neocaml-mode--font-lock-settings "neocaml")
@@ -159,43 +163,84 @@ With prefix argument FORCE, reinstall even if already installed."
      @font-lock-bracket-face))
   "Font-lock settings for `neocaml-odoc-mode'.")
 
-(defun neocaml-odoc--injection-available-p ()
-  "Non-nil if OCaml language injection is available.
-Requires Emacs 30+ (for `treesit-range-rules' with `:embed') and
-the OCaml tree-sitter grammar."
-  (and (>= emacs-major-version 30)
-       (treesit-language-available-p 'ocaml)))
+(defvar neocaml-odoc--injection-language-alist
+  '(("ocaml" . ocaml)
+    ("dune"  . dune)
+    ("opam"  . opam)
+    ("sh"    . bash)
+    ("bash"  . bash))
+  "Alist mapping odoc language tags to tree-sitter grammar symbols.
+Each entry is (TAG . GRAMMAR) where TAG is the string used in
+`{@tag[...]}' blocks and GRAMMAR is the tree-sitter language symbol.")
+
+(defun neocaml-odoc--injection-capable-p ()
+  "Non-nil if language injection is supported.
+Requires Emacs 30+ for `treesit-range-rules' with `:embed'."
+  (>= emacs-major-version 30))
+
+(defun neocaml-odoc--available-injections ()
+  "Return the subset of `neocaml-odoc--injection-language-alist' with installed grammars."
+  (when (neocaml-odoc--injection-capable-p)
+    (seq-filter (lambda (entry)
+                  (treesit-language-available-p (cdr entry)))
+                neocaml-odoc--injection-language-alist)))
+
+(defun neocaml-odoc--font-lock-for-grammar (grammar)
+  "Return font-lock settings for GRAMMAR, or nil if unavailable."
+  (pcase grammar
+    ('ocaml
+     (require 'neocaml)
+     (neocaml-mode--font-lock-settings 'ocaml))
+    ('dune
+     (require 'neocaml-dune)
+     (symbol-value 'neocaml-dune--font-lock-settings))
+    ('opam
+     (require 'neocaml-opam)
+     (symbol-value 'neocaml-opam--font-lock-settings))
+    ('bash
+     ;; Emacs built-in bash-ts-mode font-lock; not easily extractable.
+     nil)))
 
 (defun neocaml-odoc--font-lock-settings ()
   "Return font-lock settings for `neocaml-odoc-mode'.
-When OCaml injection is available, includes font-lock rules for
-embedded OCaml code inside {@ocaml[...]} blocks.  Otherwise,
-code block content gets a plain string face as fallback."
-  (append
-   neocaml-odoc--font-lock-settings
-   (if (neocaml-odoc--injection-available-p)
-       (progn
-         (require 'neocaml)
-         (neocaml-mode--font-lock-settings 'ocaml))
-     ;; No injection: highlight code_block_content as string
-     (treesit-font-lock-rules
-      :language 'odoc
-      :feature 'code
-      '((code_block_with_lang (code_block_content) @font-lock-string-face))))))
+When language injection is available, includes font-lock rules for
+embedded code inside `{@lang[...]}' blocks.  Otherwise, code block
+content gets a plain string face as fallback."
+  (let ((injections (neocaml-odoc--available-injections)))
+    (append
+     neocaml-odoc--font-lock-settings
+     (if injections
+         (cl-loop for grammar in (delete-dups (mapcar #'cdr injections))
+                  append (or (neocaml-odoc--font-lock-for-grammar grammar) nil))
+       ;; No injection: highlight code_block_content as string
+       (treesit-font-lock-rules
+        :language 'odoc
+        :feature 'code
+        '((code_block_with_lang (code_block_content) @font-lock-string-face)))))))
 
 (defun neocaml-odoc--range-settings ()
-  "Return range settings for embedded OCaml code injection.
-Injects the OCaml parser into `{@ocaml[...]}' code blocks.
-Returns nil if injection is not available."
-  (when (neocaml-odoc--injection-available-p)
-    (treesit-range-rules
-     :embed 'ocaml
-     :host 'odoc
-     :local t
-     '((code_block_with_lang
-        (language) @_lang
-        (code_block_content) @capture
-        (:match "\\`ocaml\\'" @_lang))))))
+  "Return range settings for language injection in code blocks.
+Injects parsers into `{@lang[...]}' blocks for each available grammar.
+Returns nil if no injections are available."
+  (let ((injections (neocaml-odoc--available-injections)))
+    (when injections
+      ;; Group tags by grammar, so e.g. sh and bash produce one rule
+      ;; matching either tag.
+      (let ((by-grammar (make-hash-table :test #'eq)))
+        (dolist (entry injections)
+          (push (car entry) (gethash (cdr entry) by-grammar)))
+        (apply #'append
+               (map-apply
+                (lambda (grammar tags)
+                  (treesit-range-rules
+                   :embed grammar
+                   :host 'odoc
+                   :local t
+                   `((code_block_with_lang
+                      (language) @_lang
+                      (code_block_content) @capture
+                      (:match ,(concat "\\`" (regexp-opt tags) "\\'") @_lang)))))
+                by-grammar))))))
 
 ;;; Indentation
 
@@ -249,9 +294,10 @@ See `treesit-simple-imenu-settings' for the format.")
 (define-derived-mode neocaml-odoc-mode text-mode "odoc"
   "Major mode for editing odoc documentation files.
 
-When the OCaml tree-sitter grammar is installed, embedded OCaml
-code inside {@ocaml[...]} blocks gets full syntax highlighting
-via language injection.
+When tree-sitter grammars are installed, embedded code inside
+`{@lang[...]}' blocks gets full syntax highlighting via language
+injection.  See `neocaml-odoc--injection-language-alist' for
+supported languages.
 
 \\{neocaml-odoc-mode-map}"
   (unless (treesit-ready-p 'odoc)
@@ -261,7 +307,7 @@ via language injection.
       (error "Cannot activate neocaml-odoc-mode without the odoc grammar")))
   (treesit-parser-create 'odoc)
 
-  ;; Language injection for embedded OCaml code
+  ;; Language injection for embedded code blocks
   (let ((range-settings (neocaml-odoc--range-settings)))
     (when range-settings
       (setq-local treesit-range-settings range-settings)))

--- a/neocaml-odoc.el
+++ b/neocaml-odoc.el
@@ -43,11 +43,12 @@
 
 ;;; Code:
 
-(require 'cl-lib)
-(require 'map)
 (require 'treesit)
 
-(declare-function neocaml-mode--font-lock-settings "neocaml")
+(declare-function neocaml-mode--font-lock-settings "neocaml" (language))
+
+(defvar neocaml-dune--font-lock-settings)
+(defvar neocaml-opam--font-lock-settings)
 
 (defgroup neocaml-odoc nil
   "Major mode for editing odoc files with tree-sitter."
@@ -115,9 +116,9 @@ With prefix argument FORCE, reinstall even if already installed."
 
    :language 'odoc
    :feature 'markup
-   '((bold) @font-lock-type-face
-     (italic) @font-lock-variable-name-face
-     (emphasis) @font-lock-variable-name-face)
+   '((bold) @bold
+     (italic) @italic
+     (emphasis) @bold-italic)
 
    :language 'odoc
    :feature 'code
@@ -146,8 +147,8 @@ With prefix argument FORCE, reinstall even if already installed."
 
    :language 'odoc
    :feature 'markup
-   '((superscript) @font-lock-type-face
-     (subscript) @font-lock-type-face
+   '((superscript) @font-lock-doc-markup-face
+     (subscript) @font-lock-doc-markup-face
      (raw_markup) @font-lock-preprocessor-face)
 
    :language 'odoc
@@ -194,10 +195,10 @@ Requires Emacs 30+ for `treesit-range-rules' with `:embed'."
      (neocaml-mode--font-lock-settings 'ocaml))
     ('dune
      (require 'neocaml-dune)
-     (symbol-value 'neocaml-dune--font-lock-settings))
+     neocaml-dune--font-lock-settings)
     ('opam
      (require 'neocaml-opam)
-     (symbol-value 'neocaml-opam--font-lock-settings))
+     neocaml-opam--font-lock-settings)
     ('bash
      ;; Emacs built-in bash-ts-mode font-lock; not easily extractable.
      ;; TODO Use sh-mode--treesit-settings?
@@ -212,8 +213,10 @@ content gets a plain string face as fallback."
     (append
      neocaml-odoc--font-lock-settings
      (if injections
-         (cl-loop for grammar in (delete-dups (mapcar #'cdr injections))
-                  append (or (neocaml-odoc--font-lock-for-grammar grammar) nil))
+         (mapcan (lambda (grammar)
+                   (copy-sequence
+                    (neocaml-odoc--font-lock-for-grammar grammar)))
+                 (seq-uniq (mapcar #'cdr injections)))
        ;; No injection: highlight code_block_content as string
        (treesit-font-lock-rules
         :language 'odoc
@@ -231,18 +234,21 @@ Returns nil if no injections are available."
       (let ((by-grammar (make-hash-table :test #'eq)))
         (dolist (entry injections)
           (push (car entry) (gethash (cdr entry) by-grammar)))
-        (apply #'append
-               (map-apply
-                (lambda (grammar tags)
-                  (treesit-range-rules
-                   :embed grammar
-                   :host 'odoc
-                   :local t
-                   `((code_block_with_lang
-                      (language) @_lang
-                      (code_block_content) @capture
-                      (:match ,(concat "\\`" (regexp-opt tags) "\\'") @_lang)))))
-                by-grammar))))))
+        (let ((result nil))
+          (maphash
+           (lambda (grammar tags)
+             (setq result
+                   (nconc result
+                          (treesit-range-rules
+                           :embed grammar
+                           :host 'odoc
+                           :local t
+                           `((code_block_with_lang
+                              (language) @_lang
+                              (code_block_content) @capture
+                              (:match ,(concat "\\`" (regexp-opt tags) "\\'") @_lang)))))))
+           by-grammar)
+          result)))))
 
 ;;; Indentation
 
@@ -267,6 +273,8 @@ Returns nil if no injections are available."
      ;; Headings and tags
      ((parent-is "heading") parent-bol neocaml-odoc-indent-offset)
      ((parent-is "tag") parent-bol neocaml-odoc-indent-offset)
+     ;; Paragraph text stays at column 0
+     ((parent-is "paragraph") column-0 0)
      ;; Catch-all
      (no-node parent-bol neocaml-odoc-indent-offset)))
   "Indentation rules for `neocaml-odoc-mode'.")
@@ -274,8 +282,8 @@ Returns nil if no injections are available."
 ;;; Imenu
 
 (defvar neocaml-odoc--imenu-settings
-  '(("Heading" "\\`heading\\'" nil nil)
-    ("Tag" "\\`tag_\\(?:param\\|return\\|raise\\|deprecated\\|since\\|version\\|author\\)\\'" nil nil))
+  '(("Heading" "\\`heading\\'" nil neocaml-odoc--defun-name)
+    ("Tag" "\\`tag_\\(?:param\\|return\\|raise\\|deprecated\\|since\\|version\\|author\\)\\'" nil neocaml-odoc--defun-name))
   "Imenu settings for `neocaml-odoc-mode'.
 See `treesit-simple-imenu-settings' for the format.")
 
@@ -317,10 +325,14 @@ supported languages.
   ;; Font-lock
   (setq-local treesit-font-lock-settings (neocaml-odoc--font-lock-settings))
   (setq-local treesit-font-lock-feature-list
-              '((comment heading tag definition)
-                (keyword markup code math string type)
-                (constant escape-sequence attribute builtin number reference)
-                (variable operator bracket delimiter list property label function)))
+              '((heading tag)
+                (markup code math)
+                (reference escape-sequence)
+                (list bracket
+                 ;; Injection-dependent features (active when grammars installed)
+                 comment definition keyword string type constant
+                 attribute builtin number variable operator
+                 delimiter property label function)))
 
   ;; Indentation
   (setq-local treesit-simple-indent-rules neocaml-odoc--indent-rules)

--- a/neocaml-odoc.el
+++ b/neocaml-odoc.el
@@ -1,0 +1,300 @@
+;;; neocaml-odoc.el --- Major mode for odoc (.mld) files -*- lexical-binding: t; -*-
+
+;; Copyright © 2025-2026 Bozhidar Batsov
+;;
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
+;; URL: http://github.com/bbatsov/neocaml
+;; Keywords: languages ocaml odoc
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Tree-sitter based major mode for editing odoc documentation (.mld)
+;; files.  Provides font-lock for the odoc markup language including
+;; headings, inline formatting (bold, italic, emphasis), code spans,
+;; references, links, tags, lists, tables, and code blocks.  When the
+;; OCaml tree-sitter grammar is installed, embedded OCaml code inside
+;; {@ocaml[...]} blocks gets full syntax highlighting via language
+;; injection.
+;;
+;; For the tree-sitter grammar this mode is based on,
+;; see https://github.com/tmcgilchrist/tree-sitter-odoc.
+
+;;; License:
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Code:
+
+(require 'treesit)
+
+(declare-function neocaml-mode--font-lock-settings "neocaml")
+
+(defgroup neocaml-odoc nil
+  "Major mode for editing odoc files with tree-sitter."
+  :prefix "neocaml-odoc-"
+  :group 'languages
+  :link '(url-link :tag "GitHub" "https://github.com/bbatsov/neocaml"))
+
+(defcustom neocaml-odoc-indent-offset 2
+  "Number of spaces for each indentation step in `neocaml-odoc-mode'."
+  :type 'natnum
+  :safe 'natnump
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.8.0"))
+
+;;; Grammar installation
+
+(defconst neocaml-odoc-grammar-recipes
+  '((odoc "https://github.com/tmcgilchrist/tree-sitter-odoc"
+          "master"
+          "src"))
+  "Tree-sitter grammar recipe for odoc files.
+Each entry is a list of (LANGUAGE URL REV SOURCE-DIR).
+Suitable for use as the value of `treesit-language-source-alist'.")
+
+(defun neocaml-odoc-install-grammar (&optional force)
+  "Install the odoc tree-sitter grammar if not already available.
+With prefix argument FORCE, reinstall even if already installed."
+  (interactive "P")
+  (when (or force (not (treesit-language-available-p 'odoc nil)))
+    (message "Installing odoc tree-sitter grammar...")
+    (let ((treesit-language-source-alist neocaml-odoc-grammar-recipes))
+      (treesit-install-language-grammar 'odoc))))
+
+;;; Font-lock
+
+(defvar neocaml-odoc--font-lock-settings
+  (treesit-font-lock-rules
+   :language 'odoc
+   :feature 'heading
+   '((heading) @font-lock-function-name-face)
+
+   :language 'odoc
+   :feature 'tag
+   '((tag_author) @font-lock-keyword-face
+     (tag_param) @font-lock-keyword-face
+     (tag_raise) @font-lock-keyword-face
+     (tag_return) @font-lock-keyword-face
+     (tag_see) @font-lock-keyword-face
+     (tag_since) @font-lock-keyword-face
+     (tag_before) @font-lock-keyword-face
+     (tag_version) @font-lock-keyword-face
+     (tag_deprecated) @font-lock-keyword-face
+     (tag_canonical) @font-lock-keyword-face
+     (tag_inline) @font-lock-keyword-face
+     (tag_open) @font-lock-keyword-face
+     (tag_closed) @font-lock-keyword-face
+     (tag_hidden) @font-lock-keyword-face)
+
+   :language 'odoc
+   :feature 'tag
+   '((param_name) @font-lock-variable-name-face
+     (raise_name) @font-lock-variable-name-face
+     (before_version) @font-lock-constant-face)
+
+   :language 'odoc
+   :feature 'markup
+   '((bold) @font-lock-type-face
+     (italic) @font-lock-variable-name-face
+     (emphasis) @font-lock-variable-name-face)
+
+   :language 'odoc
+   :feature 'code
+   '((code_span) @font-lock-string-face
+     (code_block) @font-lock-string-face
+     (code_block_with_lang (language) @font-lock-type-face)
+     (verbatim_block) @font-lock-string-face)
+
+   :language 'odoc
+   :feature 'math
+   '((math_span) @font-lock-number-face
+     (math_block) @font-lock-number-face)
+
+   :language 'odoc
+   :feature 'reference
+   '((simple_reference) @font-lock-constant-face
+     (reference_with_text (reference_target) @font-lock-constant-face)
+     (simple_link) @font-lock-constant-face
+     (link_with_text (link_target) @font-lock-constant-face)
+     (module_name) @font-lock-constant-face)
+
+   :language 'odoc
+   :feature 'escape-sequence
+   :override t
+   '((escape_sequence) @font-lock-escape-face)
+
+   :language 'odoc
+   :feature 'markup
+   '((superscript) @font-lock-type-face
+     (subscript) @font-lock-type-face
+     (raw_markup) @font-lock-preprocessor-face)
+
+   :language 'odoc
+   :feature 'list
+   '((unordered_list) @font-lock-bracket-face
+     (ordered_list) @font-lock-bracket-face)
+
+   :language 'odoc
+   :feature 'bracket
+   '(["[" "]" "]}" "{" "}" "{b" "{i" "{e" "{^" "{_"
+      "{!" "{{!" "{:" "{{:" "{%" "{m" "{math"
+      "{[" "{v" "{ul" "{ol" "{li" "{table" "{tr" "{th" "{td" "{t"
+      "{L" "{C" "{R" "{!modules:" "%}"]
+     @font-lock-bracket-face))
+  "Font-lock settings for `neocaml-odoc-mode'.")
+
+(defun neocaml-odoc--injection-available-p ()
+  "Non-nil if OCaml language injection is available.
+Requires Emacs 30+ (for `treesit-range-rules' with `:embed') and
+the OCaml tree-sitter grammar."
+  (and (>= emacs-major-version 30)
+       (treesit-language-available-p 'ocaml)))
+
+(defun neocaml-odoc--font-lock-settings ()
+  "Return font-lock settings for `neocaml-odoc-mode'.
+When OCaml injection is available, includes font-lock rules for
+embedded OCaml code inside {@ocaml[...]} blocks.  Otherwise,
+code block content gets a plain string face as fallback."
+  (append
+   neocaml-odoc--font-lock-settings
+   (if (neocaml-odoc--injection-available-p)
+       (progn
+         (require 'neocaml)
+         (neocaml-mode--font-lock-settings 'ocaml))
+     ;; No injection: highlight code_block_content as string
+     (treesit-font-lock-rules
+      :language 'odoc
+      :feature 'code
+      '((code_block_with_lang (code_block_content) @font-lock-string-face))))))
+
+(defun neocaml-odoc--range-settings ()
+  "Return range settings for embedded OCaml code injection.
+Injects the OCaml parser into `{@ocaml[...]}' code blocks.
+Returns nil if injection is not available."
+  (when (neocaml-odoc--injection-available-p)
+    (treesit-range-rules
+     :embed 'ocaml
+     :host 'odoc
+     :local t
+     '((code_block_with_lang
+        (language) @_lang
+        (code_block_content) @capture
+        (:match "\\`ocaml\\'" @_lang))))))
+
+;;; Indentation
+
+(defvar neocaml-odoc--indent-rules
+  `((odoc
+     ((parent-is "document") column-0 0)
+     ;; Don't reindent inside code/verbatim blocks
+     ((parent-is "code_block") no-indent 0)
+     ((parent-is "code_block_with_lang") no-indent 0)
+     ((parent-is "verbatim_block") no-indent 0)
+     ;; Lists
+     ((parent-is "unordered_list") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "ordered_list") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "light_list") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "li_list_item") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "dash_list_item") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "light_list_item") parent-bol neocaml-odoc-indent-offset)
+     ;; Tables
+     ((parent-is "table_heavy") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "table_light") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "table_row") parent-bol neocaml-odoc-indent-offset)
+     ;; Headings and tags
+     ((parent-is "heading") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "tag") parent-bol neocaml-odoc-indent-offset)
+     ;; Catch-all
+     (no-node parent-bol neocaml-odoc-indent-offset)))
+  "Indentation rules for `neocaml-odoc-mode'.")
+
+;;; Imenu
+
+(defvar neocaml-odoc--imenu-settings
+  '(("Heading" "\\`heading\\'" nil nil)
+    ("Tag" "\\`tag_\\(?:param\\|return\\|raise\\|deprecated\\|since\\|version\\|author\\)\\'" nil nil))
+  "Imenu settings for `neocaml-odoc-mode'.
+See `treesit-simple-imenu-settings' for the format.")
+
+;;; Navigation
+
+(defun neocaml-odoc--defun-name (node)
+  "Return a name for NODE suitable for imenu and which-func."
+  (let ((type (treesit-node-type node)))
+    (cond
+     ((string= type "heading")
+      (string-trim (treesit-node-text node t)))
+     ((string-prefix-p "tag_" type)
+      (string-trim (treesit-node-text node t))))))
+
+;;; Mode definition
+
+;;;###autoload
+(define-derived-mode neocaml-odoc-mode text-mode "odoc"
+  "Major mode for editing odoc documentation files.
+
+When the OCaml tree-sitter grammar is installed, embedded OCaml
+code inside {@ocaml[...]} blocks gets full syntax highlighting
+via language injection.
+
+\\{neocaml-odoc-mode-map}"
+  (unless (treesit-ready-p 'odoc)
+    (when (y-or-n-p "Odoc tree-sitter grammar is not installed.  Install it now?")
+      (neocaml-odoc-install-grammar))
+    (unless (treesit-ready-p 'odoc)
+      (error "Cannot activate neocaml-odoc-mode without the odoc grammar")))
+  (treesit-parser-create 'odoc)
+
+  ;; Language injection for embedded OCaml code
+  (let ((range-settings (neocaml-odoc--range-settings)))
+    (when range-settings
+      (setq-local treesit-range-settings range-settings)))
+
+  ;; Font-lock
+  (setq-local treesit-font-lock-settings (neocaml-odoc--font-lock-settings))
+  (setq-local treesit-font-lock-feature-list
+              '((comment heading tag definition)
+                (keyword markup code math string type)
+                (constant escape-sequence attribute builtin number reference)
+                (variable operator bracket delimiter list property label function)))
+
+  ;; Indentation
+  (setq-local treesit-simple-indent-rules neocaml-odoc--indent-rules)
+  (setq-local indent-tabs-mode nil)
+
+  ;; Imenu
+  (setq-local treesit-simple-imenu-settings neocaml-odoc--imenu-settings)
+
+  ;; Navigation
+  (setq-local treesit-defun-type-regexp
+              "\\`\\(?:heading\\|tag_param\\|tag_return\\|tag_raise\\)\\'")
+  (setq-local treesit-defun-name-function #'neocaml-odoc--defun-name)
+  (setq-local add-log-current-defun-function #'treesit-add-log-current-defun)
+
+  ;; Final newline
+  (setq-local require-final-newline mode-require-final-newline)
+
+  (treesit-major-mode-setup))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.mld\\'" . neocaml-odoc-mode))
+
+(provide 'neocaml-odoc)
+
+;;; neocaml-odoc.el ends here

--- a/neocaml-odoc.el
+++ b/neocaml-odoc.el
@@ -67,7 +67,7 @@
 
 (defconst neocaml-odoc-grammar-recipes
   '((odoc "https://github.com/tmcgilchrist/tree-sitter-odoc"
-          "master"
+          "0.1.1"
           "src"))
   "Tree-sitter grammar recipe for odoc files.
 Each entry is a list of (LANGUAGE URL REV SOURCE-DIR).

--- a/neocaml-odoc.el
+++ b/neocaml-odoc.el
@@ -215,7 +215,11 @@ With prefix argument FORCE, reinstall even if already installed."
      (tag_inline) @neocaml-odoc-tag-face
      (tag_open) @neocaml-odoc-tag-face
      (tag_closed) @neocaml-odoc-tag-face
-     (tag_hidden) @neocaml-odoc-tag-face)
+     (tag_hidden) @neocaml-odoc-tag-face
+     (tag_children_order) @neocaml-odoc-tag-face
+     (tag_toc_status) @neocaml-odoc-tag-face
+     (tag_order_category) @neocaml-odoc-tag-face
+     (tag_short_title) @neocaml-odoc-tag-face)
 
    :language 'odoc
    :feature 'tag
@@ -248,7 +252,9 @@ With prefix argument FORCE, reinstall even if already installed."
      (reference_with_text (reference_target) @neocaml-odoc-reference-face)
      (simple_link) @neocaml-odoc-link-face
      (link_with_text (link_target) @neocaml-odoc-link-face)
-     (module_name) @neocaml-odoc-reference-face)
+     (module_name) @neocaml-odoc-reference-face
+     (simple_media (media_target) @neocaml-odoc-link-face)
+     (media_with_text (media_target) @neocaml-odoc-link-face))
 
    :language 'odoc
    :feature 'escape-sequence
@@ -269,9 +275,11 @@ With prefix argument FORCE, reinstall even if already installed."
    :language 'odoc
    :feature 'bracket
    '(["[" "]" "]}" "}" "{b" "{i" "{e" "{^" "{_"
-      "{!" "{{!" "{:" "{{:" "{%" "{m" "{math"
+      "{!" "{{!" "{:" "{{:" "{%" "{m" "{math" "{@"
       "{[" "{v" "{ul" "{ol" "{li" "{table" "{tr" "{th" "{td" "{t"
-      "{L" "{C" "{R" "{!modules:" "%}"]
+      "{L" "{C" "{R" "{!modules:" "%}"
+      "{image!" "{image:" "{video!" "{video:" "{audio!" "{audio:"
+      "{{image!" "{{image:" "{{video!" "{{video:" "{{audio!" "{{audio:"]
      @neocaml-odoc-bracket-face))
   "Font-lock settings for `neocaml-odoc-mode'.")
 

--- a/neocaml-odoc.el
+++ b/neocaml-odoc.el
@@ -1,0 +1,483 @@
+;;; neocaml-odoc.el --- Major mode for odoc (.mld) files -*- lexical-binding: t; -*-
+
+;; Copyright © 2025-2026 Bozhidar Batsov
+;;
+;; Author: Tim McGilchrist <timmcgil@gmail.com>
+;;         Bozhidar Batsov <bozhidar@batsov.dev>
+;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
+;; URL: http://github.com/bbatsov/neocaml
+;; Keywords: languages ocaml odoc
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Tree-sitter based major mode for editing odoc documentation (.mld)
+;; files.  Provides font-lock for the odoc markup language including
+;; headings, inline formatting (bold, italic, emphasis), code spans,
+;; references, links, tags, lists, tables, and code blocks.  When the
+;; relevant tree-sitter grammars are installed, embedded code inside
+;; {@lang[...]} blocks gets full syntax highlighting via language
+;; injection.  Supported languages: OCaml, dune, and opam.
+;;
+;; For the tree-sitter grammar this mode is based on,
+;; see https://github.com/tmcgilchrist/tree-sitter-odoc.
+
+;;; License:
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Code:
+
+(require 'treesit)
+
+(declare-function neocaml-mode--font-lock-settings "neocaml" (language))
+
+(defvar neocaml-dune--font-lock-settings)
+(defvar neocaml-opam--font-lock-settings)
+
+(defgroup neocaml-odoc nil
+  "Major mode for editing odoc files with tree-sitter."
+  :prefix "neocaml-odoc-"
+  :group 'languages
+  :link '(url-link :tag "GitHub" "https://github.com/bbatsov/neocaml"))
+
+(defcustom neocaml-odoc-indent-offset 2
+  "Number of spaces for each indentation step in `neocaml-odoc-mode'."
+  :type 'natnum
+  :safe 'natnump
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+;;; Grammar installation
+
+(defconst neocaml-odoc-grammar-recipes
+  '((odoc "https://github.com/tmcgilchrist/tree-sitter-odoc"
+          "0.2.0"
+          "src"))
+  "Tree-sitter grammar recipe for odoc files.
+Each entry is a list of (LANGUAGE URL REV SOURCE-DIR).
+Suitable for use as the value of `treesit-language-source-alist'.")
+
+(defun neocaml-odoc-install-grammar (&optional force)
+  "Install the odoc tree-sitter grammar if not already available.
+With prefix argument FORCE, reinstall even if already installed."
+  (interactive "P")
+  (when (or force (not (treesit-language-available-p 'odoc nil)))
+    (message "Installing odoc tree-sitter grammar...")
+    (let ((treesit-language-source-alist neocaml-odoc-grammar-recipes))
+      (treesit-install-language-grammar 'odoc))))
+
+;;; Faces
+
+(defface neocaml-odoc-heading-face
+  '((t :inherit font-lock-function-name-face :weight bold))
+  "Face for odoc section headings."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-bold-face
+  '((t :inherit bold))
+  "Face for bold markup in odoc."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-italic-face
+  '((t :inherit italic))
+  "Face for italic markup in odoc."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-emphasis-face
+  '((t :inherit bold-italic))
+  "Face for emphasis markup in odoc."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-tag-face
+  '((t :inherit font-lock-keyword-face))
+  "Face for documentation tags (@param, @return, etc.)."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-tag-name-face
+  '((t :inherit font-lock-variable-name-face))
+  "Face for parameter and exception names in tags."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-tag-value-face
+  '((t :inherit font-lock-constant-face))
+  "Face for version strings in tags."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-code-face
+  '((t :inherit (fixed-pitch font-lock-constant-face)))
+  "Face for inline code spans and plain code blocks."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-verbatim-face
+  '((t :inherit (fixed-pitch font-lock-string-face)))
+  "Face for verbatim blocks."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-language-face
+  '((t :inherit font-lock-type-face))
+  "Face for the language tag in code blocks ({@ocaml[...]})."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-math-face
+  '((t :inherit font-lock-string-face))
+  "Face for math spans and blocks."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-reference-face
+  '((t :inherit link))
+  "Face for identifier references ({!Module.foo})."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-link-face
+  '((t :inherit link))
+  "Face for URL links ({:https://...})."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-escape-face
+  '((t :inherit font-lock-escape-face))
+  "Face for escape sequences."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-markup-face
+  '((t :inherit shadow))
+  "Face for structural markup (superscript, subscript delimiters)."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-raw-markup-face
+  '((t :inherit font-lock-preprocessor-face))
+  "Face for raw markup (embedded HTML/LaTeX)."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-list-face
+  '((t :inherit neocaml-odoc-markup-face))
+  "Face for list markup."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+(defface neocaml-odoc-bracket-face
+  '((t :inherit shadow))
+  "Face for odoc bracket delimiters."
+  :group 'neocaml-odoc
+  :package-version '(neocaml . "0.11.0"))
+
+;;; Font-lock
+
+(defvar neocaml-odoc--font-lock-settings
+  (treesit-font-lock-rules
+   :language 'odoc
+   :feature 'heading
+   '((heading) @neocaml-odoc-heading-face)
+
+   :language 'odoc
+   :feature 'tag
+   '((tag_author) @neocaml-odoc-tag-face
+     (tag_param) @neocaml-odoc-tag-face
+     (tag_raise) @neocaml-odoc-tag-face
+     (tag_return) @neocaml-odoc-tag-face
+     (tag_see) @neocaml-odoc-tag-face
+     (tag_since) @neocaml-odoc-tag-face
+     (tag_before) @neocaml-odoc-tag-face
+     (tag_version) @neocaml-odoc-tag-face
+     (tag_deprecated) @neocaml-odoc-tag-face
+     (tag_canonical) @neocaml-odoc-tag-face
+     (tag_inline) @neocaml-odoc-tag-face
+     (tag_open) @neocaml-odoc-tag-face
+     (tag_closed) @neocaml-odoc-tag-face
+     (tag_hidden) @neocaml-odoc-tag-face
+     (tag_children_order) @neocaml-odoc-tag-face
+     (tag_toc_status) @neocaml-odoc-tag-face
+     (tag_order_category) @neocaml-odoc-tag-face
+     (tag_short_title) @neocaml-odoc-tag-face)
+
+   :language 'odoc
+   :feature 'tag
+   :override t
+   '((param_name) @neocaml-odoc-tag-name-face
+     (raise_name) @neocaml-odoc-tag-name-face
+     (before_version) @neocaml-odoc-tag-value-face)
+
+   :language 'odoc
+   :feature 'markup
+   '((bold) @neocaml-odoc-bold-face
+     (italic) @neocaml-odoc-italic-face
+     (emphasis) @neocaml-odoc-emphasis-face)
+
+   :language 'odoc
+   :feature 'code
+   '((code_span) @neocaml-odoc-code-face
+     (code_block) @neocaml-odoc-code-face
+     (code_block_with_lang (language) @neocaml-odoc-language-face)
+     (verbatim_block) @neocaml-odoc-verbatim-face)
+
+   :language 'odoc
+   :feature 'math
+   '((math_span) @neocaml-odoc-math-face
+     (math_block) @neocaml-odoc-math-face)
+
+   :language 'odoc
+   :feature 'reference
+   '((simple_reference) @neocaml-odoc-reference-face
+     (reference_with_text (reference_target) @neocaml-odoc-reference-face)
+     (simple_link) @neocaml-odoc-link-face
+     (link_with_text (link_target) @neocaml-odoc-link-face)
+     (module_name) @neocaml-odoc-reference-face
+     (simple_media (media_target) @neocaml-odoc-link-face)
+     (media_with_text (media_target) @neocaml-odoc-link-face))
+
+   :language 'odoc
+   :feature 'escape-sequence
+   :override t
+   '((escape_sequence) @neocaml-odoc-escape-face)
+
+   :language 'odoc
+   :feature 'markup
+   '((superscript) @neocaml-odoc-markup-face
+     (subscript) @neocaml-odoc-markup-face
+     (raw_markup) @neocaml-odoc-raw-markup-face)
+
+   :language 'odoc
+   :feature 'list
+   '((unordered_list) @neocaml-odoc-list-face
+     (ordered_list) @neocaml-odoc-list-face)
+
+   :language 'odoc
+   :feature 'bracket
+   '((code_block_open_delimiter) @neocaml-odoc-bracket-face
+     (code_block_delimiter_close) @neocaml-odoc-bracket-face
+     ["[" "]" "]}" "}" "{b" "{i" "{e" "{^" "{_"
+      "{!" "{{!" "{:" "{{:" "{%" "{m" "{math" "{@"
+      "{[" "{v" "{ul" "{ol" "{li" "{table" "{tr" "{th" "{td" "{t"
+      "{L" "{C" "{R" "{!modules:" "%}"
+      "{image!" "{image:" "{video!" "{video:" "{audio!" "{audio:"
+      "{{image!" "{{image:" "{{video!" "{{video:" "{{audio!" "{{audio:"]
+     @neocaml-odoc-bracket-face))
+  "Font-lock settings for `neocaml-odoc-mode'.")
+
+(defvar neocaml-odoc--injection-language-alist
+  '(("ocaml" . ocaml)
+    ("dune"  . dune)
+    ("opam"  . opam))
+  "Alist mapping odoc language tags to tree-sitter grammar symbols.
+Each entry is (TAG . GRAMMAR) where TAG is the string used in
+`{@tag[...]}' blocks and GRAMMAR is the tree-sitter language symbol.")
+
+(defun neocaml-odoc--injection-available-p ()
+  "Non-nil if language injection is supported.
+Requires Emacs 30+ for `treesit-range-rules' with `:embed'."
+  (>= emacs-major-version 30))
+
+(defun neocaml-odoc--available-injections ()
+  "Return the subset of `neocaml-odoc--injection-language-alist' with installed grammars."
+  (when (neocaml-odoc--injection-available-p)
+    (seq-filter (lambda (entry)
+                  (treesit-language-available-p (cdr entry)))
+                neocaml-odoc--injection-language-alist)))
+
+(defun neocaml-odoc--font-lock-for-grammar (grammar)
+  "Return font-lock settings for GRAMMAR, or nil if unavailable."
+  (pcase grammar
+    ('ocaml
+     (require 'neocaml)
+     (neocaml-mode--font-lock-settings 'ocaml))
+    ('dune
+     (require 'neocaml-dune)
+     neocaml-dune--font-lock-settings)
+    ('opam
+     (require 'neocaml-opam)
+     neocaml-opam--font-lock-settings)))
+
+(defun neocaml-odoc--font-lock-settings ()
+  "Return font-lock settings for `neocaml-odoc-mode'.
+When language injection is available, includes font-lock rules for
+embedded code inside `{@lang[...]}' blocks.  The last rule gives the
+body of a code block a plain code face; a language that does inject
+fontifies its own text first, so this only covers the languages that
+don't."
+  (append
+   neocaml-odoc--font-lock-settings
+   (mapcan (lambda (entry)
+             (copy-sequence
+              (neocaml-odoc--font-lock-for-grammar (cdr entry))))
+           (neocaml-odoc--available-injections))
+   (treesit-font-lock-rules
+    :language 'odoc
+    :feature 'code
+    '((code_block_with_lang (code_block_content) @neocaml-odoc-code-face)))))
+
+(defun neocaml-odoc--range-settings ()
+  "Return range settings for language injection in code blocks.
+Injects parsers into `{@lang[...]}' blocks for each available grammar.
+Returns nil if no injections are available."
+  (mapcan
+   (lambda (entry)
+     (treesit-range-rules
+      :embed (cdr entry)
+      :host 'odoc
+      :local t
+      `((code_block_with_lang
+         (language) @_lang
+         (code_block_content) @capture
+         (:match ,(concat "\\`" (regexp-quote (car entry)) "\\'") @_lang)))))
+   (neocaml-odoc--available-injections)))
+
+;;; Indentation
+
+(defvar neocaml-odoc--indent-rules
+  `((odoc
+     ((parent-is "document") column-0 0)
+     ;; Don't reindent inside code/verbatim blocks
+     ((parent-is "code_block") no-indent 0)
+     ((parent-is "code_block_with_lang") no-indent 0)
+     ((parent-is "verbatim_block") no-indent 0)
+     ;; Lists
+     ((parent-is "unordered_list") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "ordered_list") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "light_list") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "li_list_item") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "dash_list_item") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "light_list_item") parent-bol neocaml-odoc-indent-offset)
+     ;; Tables
+     ((parent-is "table_heavy") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "table_light") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "table_row") parent-bol neocaml-odoc-indent-offset)
+     ;; Headings and tags
+     ((parent-is "heading") parent-bol neocaml-odoc-indent-offset)
+     ((parent-is "tag") parent-bol neocaml-odoc-indent-offset)
+     ;; Paragraph text stays at column 0
+     ((parent-is "paragraph") column-0 0)
+     ;; Catch-all
+     (no-node parent-bol neocaml-odoc-indent-offset)))
+  "Indentation rules for `neocaml-odoc-mode'.")
+
+;;; Imenu
+
+(defvar neocaml-odoc--imenu-settings
+  '(("Heading" "\\`heading\\'" nil neocaml-odoc--defun-name)
+    ("Tag" "\\`tag_\\(?:param\\|return\\|raise\\|deprecated\\|since\\|version\\|author\\)\\'" nil neocaml-odoc--defun-name))
+  "Imenu settings for `neocaml-odoc-mode'.
+See `treesit-simple-imenu-settings' for the format.")
+
+;;; Navigation
+
+(defun neocaml-odoc--squeeze-whitespace (text)
+  "Return TEXT trimmed, with each run of whitespace collapsed to one space."
+  (string-trim (replace-regexp-in-string "[ \t\n\r]+" " " text)))
+
+(defun neocaml-odoc--defun-name (node)
+  "Return a name for NODE suitable for imenu and which-func."
+  (let ((type (treesit-node-type node)))
+    (cond
+     ;; A heading has no field for its title: it is everything between the
+     ;; {N or {N:label marker and the closing brace, and it may wrap over
+     ;; several lines.
+     ((string= type "heading")
+      (let* ((count (treesit-node-child-count node))
+             (marker (treesit-node-child node 0))
+             (close (and (> count 1) (treesit-node-child node (1- count))))
+             (title (and marker close
+                         (neocaml-odoc--squeeze-whitespace
+                          (buffer-substring-no-properties
+                           (treesit-node-end marker)
+                           (treesit-node-start close))))))
+        (unless (equal title "") title)))
+     ((string-prefix-p "tag_" type)
+      (neocaml-odoc--squeeze-whitespace (treesit-node-text node t))))))
+
+;;; Mode definition
+
+;;;###autoload
+(define-derived-mode neocaml-odoc-mode text-mode "odoc"
+  "Major mode for editing odoc documentation files.
+
+When tree-sitter grammars are installed, embedded code inside
+`{@lang[...]}' blocks gets full syntax highlighting via language
+injection.  See `neocaml-odoc--injection-language-alist' for
+supported languages.
+
+\\{neocaml-odoc-mode-map}"
+  (when (< (treesit-library-abi-version) 14)
+    (error "The odoc grammar requires tree-sitter ABI version 14+, but \
+your Emacs was built against ABI version %d; rebuild Emacs with \
+tree-sitter >= 0.24" (treesit-library-abi-version)))
+  (unless (treesit-ready-p 'odoc)
+    (when (y-or-n-p "Odoc tree-sitter grammar is not installed.  Install it now?")
+      (neocaml-odoc-install-grammar))
+    (unless (treesit-ready-p 'odoc)
+      (error "Cannot activate neocaml-odoc-mode without the odoc grammar")))
+  (treesit-parser-create 'odoc)
+
+  ;; Language injection for embedded code blocks
+  (let ((range-settings (neocaml-odoc--range-settings)))
+    (when range-settings
+      (setq-local treesit-range-settings range-settings)))
+
+  ;; Font-lock
+  (setq-local treesit-font-lock-settings (neocaml-odoc--font-lock-settings))
+  (setq-local treesit-font-lock-feature-list
+              '(( heading tag
+                  ;; Injected grammar features — levels mirror those used
+                  ;; by `neocaml-mode', `neocaml-dune-mode', etc. so that
+                  ;; embedded code gets highlighted at the default level.
+                  comment definition keyword)
+                (markup code math
+                 string type property)
+                (reference escape-sequence
+                 attribute builtin constant number)
+                (list bracket
+                 variable operator delimiter label function)))
+
+  ;; Indentation
+  (setq-local treesit-simple-indent-rules neocaml-odoc--indent-rules)
+  (setq-local indent-tabs-mode nil)
+
+  ;; Imenu
+  (setq-local treesit-simple-imenu-settings neocaml-odoc--imenu-settings)
+
+  ;; Navigation.  Only headings: they are what `C-M-a' and `C-M-e' should
+  ;; move over in a document.
+  (setq-local treesit-defun-type-regexp "\\`heading\\'")
+  (setq-local treesit-defun-name-function #'neocaml-odoc--defun-name)
+  (setq-local add-log-current-defun-function #'treesit-add-log-current-defun)
+
+  ;; Final newline
+  (setq-local require-final-newline mode-require-final-newline)
+
+  (treesit-major-mode-setup))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.mld\\'" . neocaml-odoc-mode))
+
+(provide 'neocaml-odoc)
+
+;;; neocaml-odoc.el ends here

--- a/test/neocaml-odoc-test.el
+++ b/test/neocaml-odoc-test.el
@@ -85,15 +85,15 @@ DESCRIPTION is the test name.  Uses `neocaml-odoc-mode'."
   (describe "markup feature"
     (when-fontifying-odoc-it "fontifies bold markup"
       ("{b bold text}"
-       ("{b bold text}" font-lock-type-face)))
+       ("{b bold text}" bold)))
 
     (when-fontifying-odoc-it "fontifies italic markup"
       ("{i italic text}"
-       ("{i italic text}" font-lock-variable-name-face)))
+       ("{i italic text}" italic)))
 
     (when-fontifying-odoc-it "fontifies emphasis markup"
       ("{e emphasis text}"
-       ("{e emphasis text}" font-lock-variable-name-face))))
+       ("{e emphasis text}" bold-italic))))
 
   (describe "code feature"
     (when-fontifying-odoc-it "fontifies code spans"
@@ -207,7 +207,7 @@ This is some text."))
         (goto-char (point-min))
         (search-forward "{b bold}")
         (expect (get-text-property (match-beginning 0) 'face)
-                :to-equal 'font-lock-type-face)
+                :to-equal 'bold)
         ;; Check code span
         (goto-char (point-min))
         (search-forward "[t]")

--- a/test/neocaml-odoc-test.el
+++ b/test/neocaml-odoc-test.el
@@ -181,7 +181,41 @@ This is some text."))
         (search-forward "let")
         ;; Plain code blocks get string face, not keyword face
         (expect (get-text-property (match-beginning 0) 'face)
-                :to-equal 'font-lock-string-face)))))
+                :to-equal 'font-lock-string-face)))
+
+    (it "fontifies OCaml keywords inside {@ocaml[...]} blocks"
+      (with-temp-buffer
+        (insert "{@ocaml[\nlet x = 1\n]}")
+        (neocaml-odoc-mode)
+        (font-lock-ensure)
+        (goto-char (point-min))
+        (search-forward "let")
+        (expect (get-text-property (match-beginning 0) 'face)
+                :to-equal 'font-lock-keyword-face)))
+
+    (it "fontifies dune keywords inside {@dune[...]} blocks"
+      (unless (treesit-language-available-p 'dune)
+        (signal 'buttercup-pending "tree-sitter dune grammar not available"))
+      (with-temp-buffer
+        (insert "{@dune[\n(library\n (name mylib))\n]}")
+        (neocaml-odoc-mode)
+        (font-lock-ensure)
+        (goto-char (point-min))
+        (search-forward "library")
+        (expect (get-text-property (match-beginning 0) 'face)
+                :to-equal 'font-lock-keyword-face)))
+
+    (it "fontifies opam keywords inside {@opam[...]} blocks"
+      (unless (treesit-language-available-p 'opam)
+        (signal 'buttercup-pending "tree-sitter opam grammar not available"))
+      (with-temp-buffer
+        (insert "{@opam[\ndepends: [\n  \"ocaml\"\n]\n]}")
+        (neocaml-odoc-mode)
+        (font-lock-ensure)
+        (goto-char (point-min))
+        (search-forward "depends")
+        (expect (get-text-property (match-beginning 0) 'face)
+                :to-equal 'font-lock-keyword-face)))))
 
 (describe "neocaml-odoc integration"
   (before-all

--- a/test/neocaml-odoc-test.el
+++ b/test/neocaml-odoc-test.el
@@ -55,85 +55,85 @@ DESCRIPTION is the test name.  Uses `neocaml-odoc-mode'."
   (describe "heading feature"
     (when-fontifying-odoc-it "fontifies headings"
       ("{0 My Library}"
-       ("{0 My Library}" font-lock-function-name-face))))
+       ("{0 My Library}" neocaml-odoc-heading-face))))
 
   (describe "tag feature"
     (when-fontifying-odoc-it "fontifies @param tag"
       ("@param name The name to use."
-       ("@param" font-lock-keyword-face)))
+       ("@param" neocaml-odoc-tag-face)))
 
     (when-fontifying-odoc-it "fontifies @return tag"
       ("@return A greeting string."
-       ("@return" font-lock-keyword-face)))
+       ("@return" neocaml-odoc-tag-face)))
 
     (when-fontifying-odoc-it "fontifies @since tag"
       ("@since 1.0.0"
-       ("@since" font-lock-keyword-face)))
+       ("@since" neocaml-odoc-tag-face)))
 
     (when-fontifying-odoc-it "fontifies @deprecated tag"
       ("@deprecated Use something else."
-       ("@deprecated" font-lock-keyword-face)))
+       ("@deprecated" neocaml-odoc-tag-face)))
 
     (when-fontifying-odoc-it "fontifies @author tag"
       ("@author Jane Doe"
-       ("@author" font-lock-keyword-face)))
+       ("@author" neocaml-odoc-tag-face)))
 
     (when-fontifying-odoc-it "fontifies param name"
       ("@param name The name to use."
-       ("name" font-lock-variable-name-face))))
+       ("name" neocaml-odoc-tag-name-face))))
 
   (describe "markup feature"
     (when-fontifying-odoc-it "fontifies bold markup"
       ("{b bold text}"
-       ("{b bold text}" bold)))
+       ("{b bold text}" neocaml-odoc-bold-face)))
 
     (when-fontifying-odoc-it "fontifies italic markup"
       ("{i italic text}"
-       ("{i italic text}" italic)))
+       ("{i italic text}" neocaml-odoc-italic-face)))
 
     (when-fontifying-odoc-it "fontifies emphasis markup"
       ("{e emphasis text}"
-       ("{e emphasis text}" bold-italic))))
+       ("{e emphasis text}" neocaml-odoc-emphasis-face))))
 
   (describe "code feature"
     (when-fontifying-odoc-it "fontifies code spans"
       ("[some_code]"
-       ("[some_code]" font-lock-string-face)))
+       ("[some_code]" neocaml-odoc-code-face)))
 
     (when-fontifying-odoc-it "fontifies plain code blocks"
       ("{[\nlet x = 1\n]}"
-       ("let x = 1" font-lock-string-face)))
+       ("let x = 1" neocaml-odoc-code-face)))
 
     (when-fontifying-odoc-it "fontifies language tag in code blocks"
       ("{@ocaml[\nlet x = 1\n]}"
-       ("ocaml" font-lock-type-face)))
+       ("ocaml" neocaml-odoc-language-face)))
 
     (when-fontifying-odoc-it "fontifies verbatim blocks"
       ("{v some verbatim text v}"
-       ("some verbatim text" font-lock-string-face))))
+       ("some verbatim text" neocaml-odoc-verbatim-face))))
 
   (describe "math feature"
     (when-fontifying-odoc-it "fontifies math spans"
       ("{m x^2}"
-       ("{m x^2}" font-lock-number-face))))
+       ("{m x^2}" neocaml-odoc-math-face))))
 
   (describe "reference feature"
     (when-fontifying-odoc-it "fontifies simple references"
       ("{!Mylib.greet}"
-       ("{!Mylib.greet}" font-lock-constant-face)))
+       ("{!Mylib.greet}" neocaml-odoc-reference-face)))
 
     (when-fontifying-odoc-it "fontifies reference targets in references with text"
       ("{{!Mylib} the module}"
-       ("Mylib" font-lock-constant-face)))
+       ("Mylib" neocaml-odoc-reference-face)))
 
     (when-fontifying-odoc-it "fontifies simple links"
       ("{:https://example.com}"
-       ("{:https://example.com}" font-lock-constant-face))))
+       ("{:https://example.com}" neocaml-odoc-link-face))))
 
   (describe "escape-sequence feature"
     (when-fontifying-odoc-it "fontifies escape sequences"
       ("\\{escaped"
-       ("\\{" font-lock-escape-face)))))
+       ("\\{" neocaml-odoc-escape-face)))))
 
 (describe "neocaml-odoc indentation"
   (before-all
@@ -179,9 +179,9 @@ This is some text."))
         (font-lock-ensure)
         (goto-char (point-min))
         (search-forward "let")
-        ;; Plain code blocks get string face, not keyword face
+        ;; Plain code blocks get code face, not keyword face
         (expect (get-text-property (match-beginning 0) 'face)
-                :to-equal 'font-lock-string-face)))
+                :to-equal 'neocaml-odoc-code-face)))
 
     (it "fontifies OCaml keywords inside {@ocaml[...]} blocks"
       (with-temp-buffer
@@ -236,26 +236,26 @@ This is some text."))
         (goto-char (point-min))
         (search-forward "{0 My Library}")
         (expect (get-text-property (match-beginning 0) 'face)
-                :to-equal 'font-lock-function-name-face)
+                :to-equal 'neocaml-odoc-heading-face)
         ;; Check bold markup
         (goto-char (point-min))
         (search-forward "{b bold}")
         (expect (get-text-property (match-beginning 0) 'face)
-                :to-equal 'bold)
+                :to-equal 'neocaml-odoc-bold-face)
         ;; Check code span
         (goto-char (point-min))
         (search-forward "[t]")
         (expect (get-text-property (match-beginning 0) 'face)
-                :to-equal 'font-lock-string-face)
+                :to-equal 'neocaml-odoc-code-face)
         ;; Check @since tag
         (goto-char (point-min))
         (search-forward "@since")
         (expect (get-text-property (match-beginning 0) 'face)
-                :to-equal 'font-lock-keyword-face)
+                :to-equal 'neocaml-odoc-tag-face)
         ;; Check simple reference
         (goto-char (point-min))
         (search-forward "{!Mylib.greet}")
         (expect (get-text-property (match-beginning 0) 'face)
-                :to-equal 'font-lock-constant-face)))))
+                :to-equal 'neocaml-odoc-reference-face)))))
 
 ;;; neocaml-odoc-test.el ends here

--- a/test/neocaml-odoc-test.el
+++ b/test/neocaml-odoc-test.el
@@ -1,0 +1,227 @@
+;;; neocaml-odoc-test.el --- Tests for neocaml-odoc-mode -*- lexical-binding: t; -*-
+
+;; Copyright © 2025-2026 Bozhidar Batsov
+
+;;; Commentary:
+
+;; Buttercup tests for neocaml-odoc-mode: font-lock, indentation, and integration.
+
+;;; Code:
+
+(require 'neocaml-test-helpers)
+(require 'neocaml-odoc)
+
+;;;; Font-lock helpers (odoc-specific)
+
+(defmacro when-fontifying-odoc-it (description &rest tests)
+  "Create a Buttercup test asserting font-lock faces in odoc code.
+DESCRIPTION is the test name.  Each element of TESTS is
+  (CODE SPEC ...)
+where each SPEC is either (\"text\" FACE) for text-based matching
+or (START END FACE) for position-based matching."
+  (declare (indent 1))
+  `(it ,description
+     (dolist (test (quote ,tests))
+       (let ((content (car test))
+             (specs (cdr test)))
+         (neocaml-test--check-face-specs #'neocaml-odoc-mode content specs)))))
+
+;;;; Indentation helpers (odoc-specific)
+
+(defmacro when-indenting-odoc-it (description &rest code-strings)
+  "Create a Buttercup test that asserts each CODE-STRING indents correctly.
+DESCRIPTION is the test name.  Uses `neocaml-odoc-mode'."
+  (declare (indent 1))
+  `(it ,description
+     ,@(mapcar
+        (lambda (code)
+          `(let ((expected ,code))
+             (expect
+              (with-temp-buffer
+                (insert (neocaml-test--strip-indentation expected))
+                (neocaml-odoc-mode)
+                (indent-region (point-min) (point-max))
+                (buffer-string))
+              :to-equal expected)))
+        code-strings)))
+
+;;;; Tests
+
+(describe "neocaml-odoc font-lock"
+  (before-all
+    (unless (treesit-language-available-p 'odoc)
+      (signal 'buttercup-pending "tree-sitter odoc grammar not available")))
+
+  (describe "heading feature"
+    (when-fontifying-odoc-it "fontifies headings"
+      ("{0 My Library}"
+       ("{0 My Library}" font-lock-function-name-face))))
+
+  (describe "tag feature"
+    (when-fontifying-odoc-it "fontifies @param tag"
+      ("@param name The name to use."
+       ("@param" font-lock-keyword-face)))
+
+    (when-fontifying-odoc-it "fontifies @return tag"
+      ("@return A greeting string."
+       ("@return" font-lock-keyword-face)))
+
+    (when-fontifying-odoc-it "fontifies @since tag"
+      ("@since 1.0.0"
+       ("@since" font-lock-keyword-face)))
+
+    (when-fontifying-odoc-it "fontifies @deprecated tag"
+      ("@deprecated Use something else."
+       ("@deprecated" font-lock-keyword-face)))
+
+    (when-fontifying-odoc-it "fontifies @author tag"
+      ("@author Jane Doe"
+       ("@author" font-lock-keyword-face)))
+
+    (when-fontifying-odoc-it "fontifies param name"
+      ("@param name The name to use."
+       ("name" font-lock-variable-name-face))))
+
+  (describe "markup feature"
+    (when-fontifying-odoc-it "fontifies bold markup"
+      ("{b bold text}"
+       ("{b bold text}" font-lock-type-face)))
+
+    (when-fontifying-odoc-it "fontifies italic markup"
+      ("{i italic text}"
+       ("{i italic text}" font-lock-variable-name-face)))
+
+    (when-fontifying-odoc-it "fontifies emphasis markup"
+      ("{e emphasis text}"
+       ("{e emphasis text}" font-lock-variable-name-face))))
+
+  (describe "code feature"
+    (when-fontifying-odoc-it "fontifies code spans"
+      ("[some_code]"
+       ("[some_code]" font-lock-string-face)))
+
+    (when-fontifying-odoc-it "fontifies plain code blocks"
+      ("{[\nlet x = 1\n]}"
+       ("let x = 1" font-lock-string-face)))
+
+    (when-fontifying-odoc-it "fontifies language tag in code blocks"
+      ("{@ocaml[\nlet x = 1\n]}"
+       ("ocaml" font-lock-type-face)))
+
+    (when-fontifying-odoc-it "fontifies verbatim blocks"
+      ("{v some verbatim text v}"
+       ("some verbatim text" font-lock-string-face))))
+
+  (describe "math feature"
+    (when-fontifying-odoc-it "fontifies math spans"
+      ("{m x^2}"
+       ("{m x^2}" font-lock-number-face))))
+
+  (describe "reference feature"
+    (when-fontifying-odoc-it "fontifies simple references"
+      ("{!Mylib.greet}"
+       ("{!Mylib.greet}" font-lock-constant-face)))
+
+    (when-fontifying-odoc-it "fontifies reference targets in references with text"
+      ("{{!Mylib} the module}"
+       ("Mylib" font-lock-constant-face)))
+
+    (when-fontifying-odoc-it "fontifies simple links"
+      ("{:https://example.com}"
+       ("{:https://example.com}" font-lock-constant-face))))
+
+  (describe "escape-sequence feature"
+    (when-fontifying-odoc-it "fontifies escape sequences"
+      ("\\{escaped"
+       ("\\{" font-lock-escape-face)))))
+
+(describe "neocaml-odoc indentation"
+  (before-all
+    (unless (treesit-language-available-p 'odoc)
+      (signal 'buttercup-pending "tree-sitter odoc grammar not available")))
+
+  (when-indenting-odoc-it "indents top-level content at column 0"
+    "{0 My Library}
+
+This is some text."))
+
+(when (>= emacs-major-version 30)
+  (describe "neocaml-odoc language injection"
+    (before-all
+      (unless (treesit-language-available-p 'odoc)
+        (signal 'buttercup-pending "tree-sitter odoc grammar not available"))
+      (unless (treesit-language-available-p 'ocaml)
+        (signal 'buttercup-pending "tree-sitter OCaml grammar not available")))
+
+    (it "sets up range settings for OCaml injection"
+      (with-temp-buffer
+        (insert "{@ocaml[\nlet x = 1\n]}")
+        (let ((treesit-font-lock-level 4))
+          (neocaml-odoc-mode))
+        ;; Verify range settings are configured
+        (expect treesit-range-settings :not :to-be nil)))
+
+    (it "includes OCaml font-lock rules"
+      (with-temp-buffer
+        (insert "{@ocaml[\nlet x = 1\n]}")
+        (let ((treesit-font-lock-level 4))
+          (neocaml-odoc-mode))
+        ;; Check that OCaml font-lock rules were appended
+        (expect (length treesit-font-lock-settings)
+                :to-be-greater-than
+                (length neocaml-odoc--font-lock-settings))))
+
+    (it "does not inject OCaml into plain code blocks"
+      (with-temp-buffer
+        (insert "{[\nlet x = 1\n]}")
+        (let ((treesit-font-lock-level 4))
+          (neocaml-odoc-mode))
+        (font-lock-ensure)
+        (goto-char (point-min))
+        (search-forward "let")
+        ;; Plain code blocks get string face, not keyword face
+        (expect (get-text-property (match-beginning 0) 'face)
+                :to-equal 'font-lock-string-face)))))
+
+(describe "neocaml-odoc integration"
+  (before-all
+    (unless (treesit-language-available-p 'odoc)
+      (signal 'buttercup-pending "tree-sitter odoc grammar not available")))
+
+  (it "applies expected font-lock faces to sample.mld"
+    (let ((file (expand-file-name "test/resources/sample.mld"
+                                  (file-name-directory (or load-file-name
+                                                           buffer-file-name
+                                                           default-directory)))))
+      (with-temp-buffer
+        (insert-file-contents file)
+        (let ((treesit-font-lock-level 4))
+          (neocaml-odoc-mode))
+        (font-lock-ensure)
+        ;; Check heading
+        (goto-char (point-min))
+        (search-forward "{0 My Library}")
+        (expect (get-text-property (match-beginning 0) 'face)
+                :to-equal 'font-lock-function-name-face)
+        ;; Check bold markup
+        (goto-char (point-min))
+        (search-forward "{b bold}")
+        (expect (get-text-property (match-beginning 0) 'face)
+                :to-equal 'font-lock-type-face)
+        ;; Check code span
+        (goto-char (point-min))
+        (search-forward "[t]")
+        (expect (get-text-property (match-beginning 0) 'face)
+                :to-equal 'font-lock-string-face)
+        ;; Check @since tag
+        (goto-char (point-min))
+        (search-forward "@since")
+        (expect (get-text-property (match-beginning 0) 'face)
+                :to-equal 'font-lock-keyword-face)
+        ;; Check simple reference
+        (goto-char (point-min))
+        (search-forward "{!Mylib.greet}")
+        (expect (get-text-property (match-beginning 0) 'face)
+                :to-equal 'font-lock-constant-face)))))
+
+;;; neocaml-odoc-test.el ends here

--- a/test/neocaml-odoc-test.el
+++ b/test/neocaml-odoc-test.el
@@ -80,7 +80,23 @@ DESCRIPTION is the test name.  Uses `neocaml-odoc-mode'."
 
     (when-fontifying-odoc-it "fontifies param name"
       ("@param name The name to use."
-       ("name" neocaml-odoc-tag-name-face))))
+       ("name" neocaml-odoc-tag-name-face)))
+
+    (when-fontifying-odoc-it "fontifies @children_order tag"
+      ("@children_order intro.mld api.mld"
+       ("@children_order" neocaml-odoc-tag-face)))
+
+    (when-fontifying-odoc-it "fontifies @short_title tag"
+      ("@short_title My Page"
+       ("@short_title" neocaml-odoc-tag-face)))
+
+    (when-fontifying-odoc-it "fontifies @toc_status tag"
+      ("@toc_status open"
+       ("@toc_status" neocaml-odoc-tag-face)))
+
+    (when-fontifying-odoc-it "fontifies @order_category tag"
+      ("@order_category basics"
+       ("@order_category" neocaml-odoc-tag-face))))
 
   (describe "markup feature"
     (when-fontifying-odoc-it "fontifies bold markup"
@@ -128,7 +144,15 @@ DESCRIPTION is the test name.  Uses `neocaml-odoc-mode'."
 
     (when-fontifying-odoc-it "fontifies simple links"
       ("{:https://example.com}"
-       ("{:https://example.com}" neocaml-odoc-link-face))))
+       ("{:https://example.com}" neocaml-odoc-link-face)))
+
+    (when-fontifying-odoc-it "fontifies image media target"
+      ("{image!media/diagram.png}"
+       ("media/diagram.png" neocaml-odoc-link-face)))
+
+    (when-fontifying-odoc-it "fontifies media target in media with replacement text"
+      ("{{audio!sound.mp3} listen here}"
+       ("sound.mp3" neocaml-odoc-link-face))))
 
   (describe "escape-sequence feature"
     (when-fontifying-odoc-it "fontifies escape sequences"

--- a/test/neocaml-odoc-test.el
+++ b/test/neocaml-odoc-test.el
@@ -1,0 +1,322 @@
+;;; neocaml-odoc-test.el --- Tests for neocaml-odoc-mode -*- lexical-binding: t; -*-
+
+;; Copyright © 2025-2026 Bozhidar Batsov
+
+;;; Commentary:
+
+;; Buttercup tests for neocaml-odoc-mode: font-lock, indentation, and integration.
+
+;;; Code:
+
+(require 'neocaml-test-helpers)
+(require 'neocaml-odoc)
+
+;;;; Font-lock helpers (odoc-specific)
+
+(defmacro when-fontifying-odoc-it (description &rest tests)
+  "Create a Buttercup test asserting font-lock faces in odoc code.
+DESCRIPTION is the test name.  Each element of TESTS is
+  (CODE SPEC ...)
+where each SPEC is either (\"text\" FACE) for text-based matching
+or (START END FACE) for position-based matching."
+  (declare (indent 1))
+  `(it ,description
+     (dolist (test (quote ,tests))
+       (let ((content (car test))
+             (specs (cdr test)))
+         (neocaml-test--check-face-specs #'neocaml-odoc-mode content specs)))))
+
+;;;; Indentation helpers (odoc-specific)
+
+(defmacro when-indenting-odoc-it (description &rest code-strings)
+  "Create a Buttercup test that asserts each CODE-STRING indents correctly.
+DESCRIPTION is the test name.  Uses `neocaml-odoc-mode'."
+  (declare (indent 1))
+  `(it ,description
+     ,@(mapcar
+        (lambda (code)
+          `(let ((expected ,code))
+             (expect
+              (with-temp-buffer
+                (insert (neocaml-test--strip-indentation expected))
+                (neocaml-odoc-mode)
+                (indent-region (point-min) (point-max))
+                (buffer-string))
+              :to-equal expected)))
+        code-strings)))
+
+;;;; Tests
+
+(describe "neocaml-odoc font-lock"
+  (before-all
+    (unless (treesit-language-available-p 'odoc)
+      (signal 'buttercup-pending "tree-sitter odoc grammar not available")))
+
+  (describe "heading feature"
+    (when-fontifying-odoc-it "fontifies headings"
+      ("{0 My Library}"
+       ("{0 My Library}" neocaml-odoc-heading-face))))
+
+  (describe "tag feature"
+    (when-fontifying-odoc-it "fontifies @param tag"
+      ("@param name The name to use."
+       ("@param" neocaml-odoc-tag-face)))
+
+    (when-fontifying-odoc-it "fontifies @return tag"
+      ("@return A greeting string."
+       ("@return" neocaml-odoc-tag-face)))
+
+    (when-fontifying-odoc-it "fontifies @since tag"
+      ("@since 1.0.0"
+       ("@since" neocaml-odoc-tag-face)))
+
+    (when-fontifying-odoc-it "fontifies @deprecated tag"
+      ("@deprecated Use something else."
+       ("@deprecated" neocaml-odoc-tag-face)))
+
+    (when-fontifying-odoc-it "fontifies @author tag"
+      ("@author Jane Doe"
+       ("@author" neocaml-odoc-tag-face)))
+
+    (when-fontifying-odoc-it "fontifies param name"
+      ("@param name The name to use."
+       ("name" neocaml-odoc-tag-name-face)))
+
+    (when-fontifying-odoc-it "fontifies @children_order tag"
+      ("@children_order intro.mld api.mld"
+       ("@children_order" neocaml-odoc-tag-face)))
+
+    (when-fontifying-odoc-it "fontifies @short_title tag"
+      ("@short_title My Page"
+       ("@short_title" neocaml-odoc-tag-face)))
+
+    (when-fontifying-odoc-it "fontifies @toc_status tag"
+      ("@toc_status open"
+       ("@toc_status" neocaml-odoc-tag-face)))
+
+    (when-fontifying-odoc-it "fontifies @order_category tag"
+      ("@order_category basics"
+       ("@order_category" neocaml-odoc-tag-face))))
+
+  (describe "markup feature"
+    (when-fontifying-odoc-it "fontifies bold markup"
+      ("{b bold text}"
+       ("{b bold text}" neocaml-odoc-bold-face)))
+
+    (when-fontifying-odoc-it "fontifies italic markup"
+      ("{i italic text}"
+       ("{i italic text}" neocaml-odoc-italic-face)))
+
+    (when-fontifying-odoc-it "fontifies emphasis markup"
+      ("{e emphasis text}"
+       ("{e emphasis text}" neocaml-odoc-emphasis-face)))
+
+    (when-fontifying-odoc-it "fontifies markup that spans a newline"
+      ("Some {b bold text\nspanning lines} here."
+       ("bold text" neocaml-odoc-bold-face)
+       ("spanning lines" neocaml-odoc-bold-face)))
+
+    ;; The page title of every dune-released library looks like this; the
+    ;; heading face covers the embedded raw markup along with the rest.
+    (when-fontifying-odoc-it "fontifies a heading that embeds raw markup"
+      ("{0 Fmt {%html: <span>v0.9.0</span>%}}"
+       ("{0 Fmt {%html: <span>v0.9.0</span>%}}" neocaml-odoc-heading-face)))
+
+    (when-fontifying-odoc-it "fontifies raw markup in a paragraph"
+      ("This is a {%html: <strong>strong</strong>%} tag."
+       ("{%html: <strong>strong</strong>%}" neocaml-odoc-raw-markup-face)))
+
+    (when-fontifying-odoc-it "fontifies markup inside a light table cell"
+      ("{t | {e emph} | plain |}"
+       ("{e emph}" neocaml-odoc-emphasis-face))))
+
+  (describe "code feature"
+    (when-fontifying-odoc-it "fontifies code spans"
+      ("[some_code]"
+       ("[some_code]" neocaml-odoc-code-face)))
+
+    (when-fontifying-odoc-it "fontifies plain code blocks"
+      ("{[\nlet x = 1\n]}"
+       ("let x = 1" neocaml-odoc-code-face)))
+
+    (when-fontifying-odoc-it "fontifies language tag in code blocks"
+      ("{@ocaml[\nlet x = 1\n]}"
+       ("ocaml" neocaml-odoc-language-face)))
+
+    (when-fontifying-odoc-it "fontifies verbatim blocks"
+      ("{v some verbatim text v}"
+       ("some verbatim text" neocaml-odoc-verbatim-face)))
+
+    (when-fontifying-odoc-it "fontifies a delimited code block"
+      ("{delim@ocaml[\nlet x = 1\n]delim}"
+       ("ocaml" neocaml-odoc-language-face))))
+
+  (describe "math feature"
+    (when-fontifying-odoc-it "fontifies math spans"
+      ("{m x^2}"
+       ("{m x^2}" neocaml-odoc-math-face))))
+
+  (describe "reference feature"
+    (when-fontifying-odoc-it "fontifies simple references"
+      ("{!Mylib.greet}"
+       ("{!Mylib.greet}" neocaml-odoc-reference-face)))
+
+    (when-fontifying-odoc-it "fontifies reference targets in references with text"
+      ("{{!Mylib} the module}"
+       ("Mylib" neocaml-odoc-reference-face)))
+
+    (when-fontifying-odoc-it "fontifies simple links"
+      ("{:https://example.com}"
+       ("{:https://example.com}" neocaml-odoc-link-face)))
+
+    (when-fontifying-odoc-it "fontifies image media target"
+      ("{image!media/diagram.png}"
+       ("media/diagram.png" neocaml-odoc-link-face)))
+
+    (when-fontifying-odoc-it "fontifies media target in media with replacement text"
+      ("{{audio!sound.mp3} listen here}"
+       ("sound.mp3" neocaml-odoc-link-face))))
+
+  (describe "escape-sequence feature"
+    (when-fontifying-odoc-it "fontifies escape sequences"
+      ("\\{escaped"
+       ("\\{" neocaml-odoc-escape-face)))))
+
+(describe "neocaml-odoc indentation"
+  (before-all
+    (unless (treesit-language-available-p 'odoc)
+      (signal 'buttercup-pending "tree-sitter odoc grammar not available")))
+
+  (when-indenting-odoc-it "indents top-level content at column 0"
+    "{0 My Library}
+
+This is some text."))
+
+(when (>= emacs-major-version 30)
+  (describe "neocaml-odoc language injection"
+    (before-all
+      (unless (treesit-language-available-p 'odoc)
+        (signal 'buttercup-pending "tree-sitter odoc grammar not available"))
+      (unless (treesit-language-available-p 'ocaml)
+        (signal 'buttercup-pending "tree-sitter OCaml grammar not available")))
+
+    (it "sets up range settings for OCaml injection"
+      (with-temp-buffer
+        (insert "{@ocaml[\nlet x = 1\n]}")
+        (let ((treesit-font-lock-level 4))
+          (neocaml-odoc-mode))
+        ;; Verify range settings are configured
+        (expect treesit-range-settings :not :to-be nil)))
+
+    (it "includes OCaml font-lock rules"
+      (with-temp-buffer
+        (insert "{@ocaml[\nlet x = 1\n]}")
+        (let ((treesit-font-lock-level 4))
+          (neocaml-odoc-mode))
+        ;; Check that OCaml font-lock rules were appended
+        (expect (length treesit-font-lock-settings)
+                :to-be-greater-than
+                (length neocaml-odoc--font-lock-settings))))
+
+    (it "does not inject OCaml into plain code blocks"
+      (with-temp-buffer
+        (insert "{[\nlet x = 1\n]}")
+        (let ((treesit-font-lock-level 4))
+          (neocaml-odoc-mode))
+        (font-lock-ensure)
+        (goto-char (point-min))
+        ;; Plain code blocks get code face, not keyword face
+        (expect "let" :to-have-face 'neocaml-odoc-code-face)))
+
+    (it "fontifies OCaml keywords inside {@ocaml[...]} blocks"
+      (with-temp-buffer
+        (insert "{@ocaml[\nlet x = 1\n]}")
+        (neocaml-odoc-mode)
+        (font-lock-ensure)
+        (goto-char (point-min))
+        (expect "let" :to-have-face 'font-lock-keyword-face)))
+
+    (it "fontifies dune keywords inside {@dune[...]} blocks"
+      (unless (treesit-language-available-p 'dune)
+        (signal 'buttercup-pending "tree-sitter dune grammar not available"))
+      (with-temp-buffer
+        (insert "{@dune[\n(library\n (name mylib))\n]}")
+        (neocaml-odoc-mode)
+        (font-lock-ensure)
+        (goto-char (point-min))
+        (expect "library" :to-have-face 'font-lock-keyword-face)))
+
+    (it "fontifies OCaml keywords inside a delimited code block"
+      (with-temp-buffer
+        (insert "{delim@ocaml[\nlet x = 1\n]delim}")
+        (neocaml-odoc-mode)
+        (font-lock-ensure)
+        (goto-char (point-min))
+        (expect "let" :to-have-face 'font-lock-keyword-face)))
+
+    (it "falls back to a code face for languages it cannot inject"
+      (with-temp-buffer
+        (insert "{@python[\nprint(1)\n]}")
+        (neocaml-odoc-mode)
+        (font-lock-ensure)
+        (goto-char (point-min))
+        (expect "print" :to-have-face 'neocaml-odoc-code-face)))
+
+    (it "fontifies opam keywords inside {@opam[...]} blocks"
+      (unless (treesit-language-available-p 'opam)
+        (signal 'buttercup-pending "tree-sitter opam grammar not available"))
+      (with-temp-buffer
+        (insert "{@opam[\ndepends: [\n  \"ocaml\"\n]\n]}")
+        (neocaml-odoc-mode)
+        (font-lock-ensure)
+        (goto-char (point-min))
+        (expect "depends" :to-have-face 'font-lock-keyword-face)))))
+
+(describe "neocaml-odoc imenu"
+  (before-all
+    (unless (treesit-language-available-p 'odoc)
+      (signal 'buttercup-pending "tree-sitter odoc grammar not available")))
+
+  (it "names a heading by its title, without the marker"
+    (with-temp-buffer
+      (insert "{0 My Library}\n\n{1:intro Getting\nStarted}\n")
+      (neocaml-odoc-mode)
+      (expect (mapcar #'car (treesit-simple-imenu))
+              :to-equal '("Heading"))
+      (expect (mapcar #'car (cdr (assoc "Heading" (treesit-simple-imenu))))
+              :to-equal '("My Library" "Getting Started"))))
+
+  (it "names a tag by its whole marker"
+    (with-temp-buffer
+      (insert "{0 T}\n\n@param name The name to greet.\n")
+      (neocaml-odoc-mode)
+      (expect (mapcar #'car (cdr (assoc "Tag" (treesit-simple-imenu))))
+              :to-equal '("@param name")))))
+
+(describe "neocaml-odoc integration"
+  (before-all
+    (unless (treesit-language-available-p 'odoc)
+      (signal 'buttercup-pending "tree-sitter odoc grammar not available")))
+
+  (it "applies expected font-lock faces to sample.mld"
+    (let ((file (expand-file-name "test/resources/sample.mld"
+                                  (file-name-directory (or load-file-name
+                                                           buffer-file-name
+                                                           default-directory)))))
+      (with-temp-buffer
+        (insert-file-contents file)
+        (let ((treesit-font-lock-level 4))
+          (neocaml-odoc-mode))
+        (font-lock-ensure)
+        (goto-char (point-min))
+        (expect "{0 My Library}" :to-have-face 'neocaml-odoc-heading-face)
+        (goto-char (point-min))
+        (expect "{b bold}" :to-have-face 'neocaml-odoc-bold-face)
+        (goto-char (point-min))
+        (expect "[t]" :to-have-face 'neocaml-odoc-code-face)
+        (goto-char (point-min))
+        (expect "@since" :to-have-face 'neocaml-odoc-tag-face)
+        (goto-char (point-min))
+        (expect "{!Mylib.greet}" :to-have-face 'neocaml-odoc-reference-face)))))
+
+;;; neocaml-odoc-test.el ends here

--- a/test/resources/sample.mld
+++ b/test/resources/sample.mld
@@ -1,0 +1,73 @@
+{0 My Library}
+
+This is the documentation for my library.
+It supports {b bold}, {i italic}, and {e emphasis} text.
+
+{1 Getting Started}
+
+Install the package with opam:
+
+{@opam[
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.0"}
+]
+]}
+
+Add it to your dune file:
+
+{@dune[
+(library
+ (name mylib)
+ (libraries base))
+]}
+
+{1 Examples}
+
+Here is a simple example:
+
+{@ocaml[
+open Mylib
+
+let greet name =
+  Printf.printf "Hello, %s!\n" name
+
+let () = greet "world"
+]}
+
+You can also run shell commands:
+
+{@sh[
+opam install mylib
+dune build
+]}
+
+{2 API Reference}
+
+The main entry point is {!Mylib.greet}.
+See {{!Mylib} the module documentation} for details.
+
+{3 Types}
+
+The core type is [t]:
+
+{[
+type t = {
+  name : string;
+  value : int;
+}
+]}
+
+{1 Mathematical Background}
+
+The complexity is {m O(n \log n)} for the general case.
+
+{math \sum_{i=0}^{n} x_i^2}
+
+{1 Version History}
+
+@since 1.0.0
+@author Jane Doe
+@deprecated Use {!Mylib.greet_v2} instead.
+@param name The name to greet.
+@return A greeting string.

--- a/test/resources/sample.mld
+++ b/test/resources/sample.mld
@@ -1,0 +1,86 @@
+{0 My Library}
+
+This is the documentation for my library.
+It supports {b bold}, {i italic}, and {e emphasis} text.
+
+{1 Getting Started}
+
+Install the package with opam:
+
+{@opam[
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.0"}
+]
+]}
+
+Add it to your dune file:
+
+{@dune[
+(library
+ (name mylib)
+ (libraries base))
+]}
+
+{1 Examples}
+
+Here is a simple example:
+
+{@ocaml[
+open Mylib
+
+let greet name =
+  Printf.printf "Hello, %s!\n" name
+
+let () = greet "world"
+]}
+
+A code block in a language we don't inject still reads as code:
+
+{@python[
+print("hello")
+]}
+
+{2 API Reference}
+
+The main entry point is {!Mylib.greet}.
+See {{!Mylib} the module documentation} for details.
+
+{3 Types}
+
+The core type is [t]:
+
+{[
+type t = {
+  name : string;
+  value : int;
+}
+]}
+
+{1 Mathematical Background}
+
+The complexity is {m O(n \log n)} for the general case.
+
+{math \sum_{i=0}^{n} x_i^2}
+
+{1 Prose That Wraps}
+
+Inline markup may {b span more than one
+line}, as may {{!Mylib.greet} a reference with
+replacement text}.
+
+- A list item may run onto the following line,
+  which is still part of the same item.
+- A second item.
+
+{t | Syntax | Meaning |
+   |--------|---------|
+   | {e a}  | emphasis |}
+
+{1 Version History}
+
+@since 1.0.0
+@author Jane Doe
+@deprecated Use {!Mylib.greet_v2} instead.
+@param name The name to greet.
+@return A greeting string.


### PR DESCRIPTION
Tree-sitter based major mode for editing odoc documentation (.mld) files, provides full syntax highlighting for OCaml code blocks.

I'm working on syntax highlighting for common code block languages like dune, opam and sh/bash. That covers the common cases I use and can be extended for other languages.

This is what it looks like with an OCaml code block.
<img width="706" height="412" alt="Screenshot 2026-04-06 at 9 11 59 pm" src="https://github.com/user-attachments/assets/530f53a1-0f14-49ae-ab2f-aed95aff5a21" />

Needs some testing and updating the copy-n-paste comments from other neocaml-*.el files. :-) 