### PR TITLE
Add neocaml-backward-up-list for jumping to enclosing module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### New features
+
+- [#47](https://github.com/bbatsov/neocaml/issues/47): Add `neocaml-backward-up-list`, bound to `C-M-u`, for jumping out of the enclosing OCaml block (`struct`/`sig`/`object`, records, arrays, etc.). The built-in `backward-up-list` doesn't understand keyword-delimited constructs on Emacs 29/30.
+
 ## 0.7.1 (2026-03-31)
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ standard Emacs keybindings, but backed by the AST rather than heuristics:
 | `C-M-b` | `backward-sexp` | Move backward over a balanced expression |
 | `M-a` | `backward-sentence` | Move to the beginning of the current statement (Emacs 30+) |
 | `M-e` | `forward-sentence` | Move to the end of the current statement (Emacs 30+) |
+| `C-M-u` | `neocaml-backward-up-list` | Move out to the enclosing `struct`/`sig`/`object`, record, array, or paren group |
+
+> [!NOTE]
+> The built-in `backward-up-list` only understands syntax-table parens, so on
+> Emacs 29/30 it can't walk out of a `module Foo = struct ... end` block.
+> neocaml ships `neocaml-backward-up-list` as a tree-sitter-aware replacement
+> bound to `C-M-u`. On Emacs 31+ the built-in already consults
+> `treesit-thing-settings`, so the command simply delegates to it.
 
 "Definitions" include `let` bindings, type definitions, module bindings, class
 definitions, exceptions, and externals. "Statements" cover the same plus

--- a/neocaml.el
+++ b/neocaml.el
@@ -824,6 +824,38 @@ ARG is as in `forward-sexp-function'."
           (treesit-forward-sexp arg)
         (neocaml-forward-sexp arg)))))
 
+(defconst neocaml--list-node-types
+  '("parenthesized_expression"
+    "parenthesized_operator"
+    "parenthesized_pattern"
+    "parenthesized_type"
+    "parenthesized_class_expression"
+    "parenthesized_module_expression"
+    "parenthesized_module_type"
+    "list_expression"
+    "list_pattern"
+    "list_binding_pattern"
+    "array_expression"
+    "array_pattern"
+    "array_binding_pattern"
+    "record_expression"
+    "record_pattern"
+    "record_binding_pattern"
+    "record_declaration"
+    "object_expression"
+    "object_type"
+    "object_copy_expression"
+    "polymorphic_variant_type"
+    "package_type"
+    "signature"
+    "structure"
+    "class_body_type")
+  "Tree-sitter node types treated as `list' things for navigation.")
+
+(defconst neocaml--list-node-regex
+  (regexp-opt neocaml--list-node-types 'symbols)
+  "Regex matching `neocaml--list-node-types'.")
+
 (defun neocaml--thing-settings (language)
   "Return `treesit-thing-settings' definitions for LANGUAGE.
 Configures sexp, list, sentence, text, and comment navigation.
@@ -838,32 +870,7 @@ This makes commands like `delete-pair' work correctly."
      (sexp (not ,(rx (or "{" "}" "(" ")" "[" "]" "[|" "|]"
                          "," "." ";" ";;" ":" "::" ":>" "->"
                          "<-" "=" "|" ".."))))
-     (list ,(regexp-opt '("parenthesized_expression"
-                          "parenthesized_operator"
-                          "parenthesized_pattern"
-                          "parenthesized_type"
-                          "parenthesized_class_expression"
-                          "parenthesized_module_expression"
-                          "parenthesized_module_type"
-                          "list_expression"
-                          "list_pattern"
-                          "list_binding_pattern"
-                          "array_expression"
-                          "array_pattern"
-                          "array_binding_pattern"
-                          "record_expression"
-                          "record_pattern"
-                          "record_binding_pattern"
-                          "record_declaration"
-                          "object_expression"
-                          "object_type"
-                          "object_copy_expression"
-                          "polymorphic_variant_type"
-                          "package_type"
-                          "signature"
-                          "structure"
-                          "class_body_type")
-                        'symbols))
+     (list ,neocaml--list-node-regex)
      (sentence ,(regexp-opt '("value_definition"
                               "type_definition"
                               "exception_definition"
@@ -882,6 +889,40 @@ This makes commands like `delete-pair' work correctly."
                               "instance_variable_specification")))
      (text ,(regexp-opt '("comment" "string" "quoted_string" "character")))
      (comment "comment"))))
+
+(defun neocaml-backward-up-list (&optional arg)
+  "Move backward out of one level of OCaml list-like construct.
+With ARG, do this that many times.  A negative ARG means move
+forward but still to a less deep spot.
+
+Unlike the built-in `backward-up-list', this recognises OCaml
+constructs delimited by keywords (`struct'/`end', `sig'/`end',
+`object'/`end') in addition to ordinary parens, brackets and
+braces.  Useful for jumping out to the enclosing module, signature
+or object from somewhere inside its body.
+
+On Emacs 31+, the built-in `backward-up-list' already understands
+these constructs via `treesit-thing-settings', so this command
+simply delegates to it there."
+  (interactive "^p")
+  (if (>= emacs-major-version 31)
+      (backward-up-list arg t t)
+    (let ((arg (or arg 1)))
+      (dotimes (_ (abs arg))
+        (let* ((node (treesit-node-at (point)))
+               (parent (treesit-parent-until
+                        node
+                        (lambda (n)
+                          (and (string-match-p neocaml--list-node-regex
+                                               (treesit-node-type n))
+                               (if (< arg 0)
+                                   (> (treesit-node-end n) (point))
+                                 (< (treesit-node-start n) (point))))))))
+          (unless parent
+            (user-error "At top level"))
+          (goto-char (if (< arg 0)
+                         (treesit-node-end parent)
+                       (treesit-node-start parent))))))))
 
 (defun neocaml-mark-sentence ()
   "Mark the current statement around point.
@@ -1164,6 +1205,7 @@ The information is also copied to the kill ring."
     (define-key map (kbd "C-c C-a") #'ff-find-other-file)
     (define-key map (kbd "C-c 4 C-a") #'ff-find-other-file-other-window)
     (define-key map (kbd "C-c C-c") #'compile)
+    (define-key map (kbd "C-M-u") #'neocaml-backward-up-list)
     (easy-menu-define neocaml-mode-menu map "Neocaml Mode Menu"
       '("OCaml"
         ("Navigate"
@@ -1172,7 +1214,8 @@ The information is also copied to the kill ring."
          ["Forward Expression" forward-sexp]
          ["Backward Expression" backward-sexp]
          ["Forward Statement" forward-sentence]
-         ["Backward Statement" backward-sentence])
+         ["Backward Statement" backward-sentence]
+         ["Up to Enclosing Block" neocaml-backward-up-list])
         ("Find..."
          ["Find Interface/Implementation" ff-find-other-file]
          ["Find Interface/Implementation in other window" ff-find-other-file-other-window])

--- a/test/neocaml-navigation-test.el
+++ b/test/neocaml-navigation-test.el
@@ -373,4 +373,44 @@
         (outline-next-heading)
         (expect (looking-at "type t") :to-be-truthy)))))
 
+;;;; backward-up-list
+
+(describe "navigation: neocaml-backward-up-list"
+  (before-all
+    (unless (treesit-language-available-p 'ocaml)
+      (signal 'buttercup-pending "tree-sitter OCaml grammar not available")))
+
+  (it "jumps from inside a struct to the enclosing struct keyword"
+    (with-neocaml-buffer "module Foo = struct
+  let bar = 1
+  let baz = 2
+end"
+      (goto-char (point-min))
+      (search-forward "baz")
+      (backward-char 1)
+      (neocaml-backward-up-list)
+      (expect (looking-at "struct") :to-be-truthy)))
+
+  (it "walks out of nested structs one level at a time"
+    (with-neocaml-buffer "module Outer = struct
+  module Inner = struct
+    let x = (1 + 2)
+  end
+end"
+      (goto-char (point-min))
+      (search-forward "1 + 2")
+      (backward-char 3)
+      (neocaml-backward-up-list)
+      (expect (char-after) :to-equal ?\()
+      (neocaml-backward-up-list)
+      (expect (looking-at "struct") :to-be-truthy)
+      (neocaml-backward-up-list)
+      (expect (looking-at "struct") :to-be-truthy)
+      (expect (line-number-at-pos) :to-equal 1)))
+
+  (it "signals an error at the top level"
+    (with-neocaml-buffer "let x = 1"
+      (goto-char (point-min))
+      (expect (neocaml-backward-up-list) :to-throw 'user-error))))
+
 ;;; neocaml-navigation-test.el ends here


### PR DESCRIPTION
On Emacs 29/30 `C-M-u` inside a `module Foo = struct ... end` just errors with "Unbalanced parentheses" because the built-in `backward-up-list` only knows about syntax-table parens. This adds a treesit-aware `neocaml-backward-up-list` bound to `C-M-u` that walks up to the nearest enclosing struct/sig/object/record/array/paren node. On Emacs 31+ the builtin already handles this via `treesit-thing-settings`, so we just delegate.

Fixes #47.