### PR TITLE
Include per-grammar ABI version in bug report info

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
         System: darwin
         neocaml: 0.3.0
         Tree-sitter ABI: 15
-        Grammars: ocaml (expected: v0.24.2), ocaml-interface (expected: v0.24.2)
+        Grammars: ocaml (ABI 14, expected: v0.24.2), ocaml-interface (ABI 14, expected: v0.24.2)
         Eglot: active
       render: text
     validations:

--- a/neocaml.el
+++ b/neocaml.el
@@ -1146,8 +1146,9 @@ SOFT works the same as in `comment-indent-new-line'."
 (defun neocaml--grammar-info (language)
   "Return a string describing the status of the LANGUAGE grammar."
   (if (treesit-language-available-p language)
-      (let ((recipe (assq language neocaml-grammar-recipes)))
-        (format "%s (expected: %s)" language (or (nth 2 recipe) "unknown")))
+      (let ((recipe (assq language neocaml-grammar-recipes))
+            (abi (treesit-language-abi-version language)))
+        (format "%s (ABI %s, expected: %s)" language abi (or (nth 2 recipe) "unknown")))
     (format "%s (not installed)" language)))
 
 (defun neocaml-bug-report-info ()


### PR DESCRIPTION
Shows the actual ABI version of each installed grammar in `M-x neocaml-bug-report-info` output, e.g.:

```
Grammars: ocaml (ABI 14, expected: v0.24.2), ocaml-interface (ABI 14, expected: v0.24.2)
```

Helps diagnose cases where Emacs was built against one tree-sitter ABI but grammars were compiled for a different one. Prompted by #49.