### PR TITLE
Support dune-workspace.* file variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#41](https://github.com/bbatsov/neocaml/issues/41): `neocaml-dune-mode` now activates for `dune-workspace` file variants like `dune-workspace.ci` and `dune-workspace.5.3`.
 - [#47](https://github.com/bbatsov/neocaml/issues/47): Add `neocaml-backward-up-list`, bound to `C-M-u`, for jumping out of the enclosing OCaml block (`struct`/`sig`/`object`, records, arrays, etc.). The built-in `backward-up-list` doesn't understand keyword-delimited constructs on Emacs 29/30.
 
 ## 0.7.1 (2026-03-31)

--- a/neocaml-dune.el
+++ b/neocaml-dune.el
@@ -276,9 +276,11 @@ tree-sitter >= 0.25.0" (treesit-library-abi-version)))
 (progn
   ;; Matches "dune" files (e.g., src/dune) but not dune-project or dune-workspace
   (add-to-list 'auto-mode-alist '("/dune\\'" . neocaml-dune-mode))
-  ;; dune-project and dune-workspace use the same grammar and mode
+  ;; dune-project and dune-workspace use the same grammar and mode.
+  ;; dune-workspace files may have a dot-suffix (e.g., dune-workspace.ci,
+  ;; dune-workspace.5.3) used by dune-pkg workflows.
   (add-to-list 'auto-mode-alist '("/dune-project\\'" . neocaml-dune-mode))
-  (add-to-list 'auto-mode-alist '("/dune-workspace\\'" . neocaml-dune-mode)))
+  (add-to-list 'auto-mode-alist '("/dune-workspace\\(?:\\..*\\)?\\'" . neocaml-dune-mode)))
 
 (provide 'neocaml-dune)
 

--- a/test/neocaml-dune-test.el
+++ b/test/neocaml-dune-test.el
@@ -228,4 +228,29 @@ DESCRIPTION is the test name.  Uses `neocaml-dune-mode'."
         (neocaml-dune-format-buffer)
         (expect (buffer-string) :to-equal formatted)))))
 
+(describe "neocaml-dune auto-mode-alist"
+  (it "activates for dune files"
+    (expect (assoc-default "/project/src/dune" auto-mode-alist 'string-match-p)
+            :to-equal 'neocaml-dune-mode))
+
+  (it "activates for dune-project"
+    (expect (assoc-default "/project/dune-project" auto-mode-alist 'string-match-p)
+            :to-equal 'neocaml-dune-mode))
+
+  (it "activates for dune-workspace"
+    (expect (assoc-default "/project/dune-workspace" auto-mode-alist 'string-match-p)
+            :to-equal 'neocaml-dune-mode))
+
+  (it "activates for dune-workspace.ci"
+    (expect (assoc-default "/project/dune-workspace.ci" auto-mode-alist 'string-match-p)
+            :to-equal 'neocaml-dune-mode))
+
+  (it "activates for dune-workspace.5.3"
+    (expect (assoc-default "/project/dune-workspace.5.3" auto-mode-alist 'string-match-p)
+            :to-equal 'neocaml-dune-mode))
+
+  (it "does not activate for dune-workspace-notes.txt"
+    (expect (assoc-default "/project/dune-workspace-notes.txt" auto-mode-alist 'string-match-p)
+            :not :to-equal 'neocaml-dune-mode)))
+
 ;;; neocaml-dune-test.el ends here


### PR DESCRIPTION
Extends the auto-mode-alist pattern for dune-workspace to also match suffixed variants like `dune-workspace.ci` and `dune-workspace.5.3`, which are becoming common with dune-pkg workflows. Files without a dot suffix (like `dune-workspace-notes.txt`) are intentionally excluded.

Fixes #41.