### PR TITLE
[Fix #53] Strip dune format-dune-file directory markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### Bug fixes
+
+- [#53](https://github.com/bbatsov/neocaml/issues/53): Strip `Entering directory` / `Leaving directory` markers that newer dune versions emit around `dune format-dune-file` output, so they no longer end up wrapping the formatted buffer.
+
 ## 0.8.0 (2026-04-10)
 
 ### New features

--- a/neocaml-dune.el
+++ b/neocaml-dune.el
@@ -93,6 +93,13 @@ buffer text with the formatted output, preserving point."
                                               "format-dune-file")))
           (if (zerop exit-code)
               (progn
+                (with-current-buffer outbuf
+                  ;; Strip the "Entering directory" / "Leaving directory"
+                  ;; markers dune emits when invoked from a sub-directory of a
+                  ;; project, so they don't end up wrapping the formatted
+                  ;; content (issue #53).
+                  (goto-char (point-min))
+                  (flush-lines "^\\(?:Entering\\|Leaving\\) directory '"))
                 (erase-buffer)
                 (insert-buffer-substring outbuf)
                 (goto-char (min orig-point (point-max)))

--- a/test/neocaml-dune-test.el
+++ b/test/neocaml-dune-test.el
@@ -226,7 +226,27 @@ DESCRIPTION is the test name.  Uses `neocaml-dune-mode'."
         (insert formatted)
         (neocaml-dune-mode)
         (neocaml-dune-format-buffer)
-        (expect (buffer-string) :to-equal formatted)))))
+        (expect (buffer-string) :to-equal formatted))))
+
+  (it "strips Entering/Leaving directory markers from dune's output"
+    ;; Newer dune versions wrap the formatted output in `Entering directory'
+    ;; and `Leaving directory' messages when invoked from a sub-directory of a
+    ;; project (issue #53).  Mock `call-process-region' to inject those lines
+    ;; deterministically rather than relying on a specific dune version.
+    (cl-letf (((symbol-function 'call-process-region)
+               (lambda (_start _end _program &optional _delete buffer
+                               _display &rest _args)
+                 (with-current-buffer buffer
+                   (insert "Entering directory '/some/proj'\n"
+                           "(library\n (name foo))\n"
+                           "Leaving directory '/some/proj'\n"))
+                 0)))
+      (with-temp-buffer
+        (insert "(library (name foo))")
+        (neocaml-dune-mode)
+        (neocaml-dune-format-buffer)
+        (expect (buffer-string)
+                :to-equal "(library\n (name foo))\n")))))
 
 (describe "neocaml-dune auto-mode-alist"
   (it "activates for dune files"


### PR DESCRIPTION
Newer dune versions emit `Entering directory '...'` / `Leaving directory '...'` lines around `dune format-dune-file` output when invoked from inside a project. With our `call-process-region` setup those ended up wrapping the formatted buffer (reported in #53 against dune 3.22.0).

Filter the lines out of the output buffer before swapping in the formatted contents. Added a buttercup test that mocks `call-process-region` to inject the wrapper lines, so the regression is locked regardless of the local dune version.

Fixes #53.