### PR TITLE
[#53] Separate stderr in dune-format-buffer instead of stripping markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- [#53](https://github.com/bbatsov/neocaml/issues/53): Strip `Entering directory` / `Leaving directory` markers that newer dune versions emit around `dune format-dune-file` output, so they no longer end up wrapping the formatted buffer.
+- [#53](https://github.com/bbatsov/neocaml/issues/53): Capture stderr separately when running `dune format-dune-file`, so the `Entering directory` / `Leaving directory` markers newer dune versions emit on stderr no longer wrap the formatted buffer.
 
 ## 0.8.0 (2026-04-10)
 

--- a/neocaml-dune.el
+++ b/neocaml-dune.el
@@ -85,29 +85,29 @@ Pipes the buffer content through the command and replaces the
 buffer text with the formatted output, preserving point."
   (interactive)
   (let ((outbuf (generate-new-buffer " *neocaml-dune-format*"))
+        ;; Send stderr to its own file so dune's `Entering directory' /
+        ;; `Leaving directory' markers (emitted on stderr from dune 3.21+
+        ;; when invoked inside a project) don't wrap the formatted output.
+        (errfile (make-temp-file "neocaml-dune-format-err"))
         (orig-point (point))
         (orig-window-start (window-start)))
     (unwind-protect
         (let ((exit-code (call-process-region (point-min) (point-max)
-                                              "dune" nil outbuf nil
+                                              "dune" nil
+                                              (list outbuf errfile) nil
                                               "format-dune-file")))
           (if (zerop exit-code)
               (progn
-                (with-current-buffer outbuf
-                  ;; Strip the "Entering directory" / "Leaving directory"
-                  ;; markers dune emits when invoked from a sub-directory of a
-                  ;; project, so they don't end up wrapping the formatted
-                  ;; content (issue #53).
-                  (goto-char (point-min))
-                  (flush-lines "^\\(?:Entering\\|Leaving\\) directory '"))
                 (erase-buffer)
                 (insert-buffer-substring outbuf)
                 (goto-char (min orig-point (point-max)))
                 (set-window-start (selected-window) orig-window-start))
             (user-error "Dune format-dune-file failed: %s"
-                        (with-current-buffer outbuf
+                        (with-temp-buffer
+                          (insert-file-contents errfile)
                           (string-trim (buffer-string))))))
-      (kill-buffer outbuf))))
+      (kill-buffer outbuf)
+      (delete-file errfile))))
 
 (defun neocaml-dune--format-before-save ()
   "Format the buffer before saving if `neocaml-dune-format-on-save' is non-nil."

--- a/test/neocaml-dune-test.el
+++ b/test/neocaml-dune-test.el
@@ -228,18 +228,21 @@ DESCRIPTION is the test name.  Uses `neocaml-dune-mode'."
         (neocaml-dune-format-buffer)
         (expect (buffer-string) :to-equal formatted))))
 
-  (it "strips Entering/Leaving directory markers from dune's output"
-    ;; Newer dune versions wrap the formatted output in `Entering directory'
-    ;; and `Leaving directory' messages when invoked from a sub-directory of a
-    ;; project (issue #53).  Mock `call-process-region' to inject those lines
-    ;; deterministically rather than relying on a specific dune version.
+  (it "keeps stderr output from dune out of the formatted buffer"
+    ;; From dune 3.21, `format-dune-file' walks up to the project root and
+    ;; prints `Entering directory' / `Leaving directory' markers on stderr
+    ;; (issue #53).  Verify the call separates stderr from stdout so those
+    ;; markers never end up in the formatted buffer.
     (cl-letf (((symbol-function 'call-process-region)
                (lambda (_start _end _program &optional _delete buffer
                                _display &rest _args)
-                 (with-current-buffer buffer
-                   (insert "Entering directory '/some/proj'\n"
-                           "(library\n (name foo))\n"
-                           "Leaving directory '/some/proj'\n"))
+                 (pcase-let ((`(,real-dest ,error-dest) buffer))
+                   (with-current-buffer real-dest
+                     (insert "(library\n (name foo))\n"))
+                   (with-temp-buffer
+                     (insert "Entering directory '/some/proj'\n"
+                             "Leaving directory '/some/proj'\n")
+                     (write-region nil nil error-dest nil 'no-message)))
                  0)))
       (with-temp-buffer
         (insert "(library (name foo))")


### PR DESCRIPTION
Follow-up to #54.

Dune emits the `Entering directory` / `Leaving directory` wrappers on stderr (`Format.err_formatter` / `User_message.prerr` in `otherlibs/stdune/src/console.ml`). The previous fix merged stderr into the same buffer as stdout and then filtered the lines back out by regex. Cleaner: separate the streams in the `call-process-region` call so the markers never reach the output buffer in the first place.

Side benefit: the failure path now reports just stderr instead of "stdout + stderr trimmed", which is more useful when dune actually fails.

Considered using `--no-print-directory` instead (suggested in #54), but that flag was only added to `format-dune-file` in dune 3.21 (PR ocaml/dune#11865, the same change that introduced the bug); on older dune it errors with `unknown option`, so we'd need version detection.

Test mocks `call-process-region` to write stdout content to the real destination buffer and stderr noise to the error file; the formatted buffer should contain only the stdout content.