### PR TITLE
Highlight function-typed val specs in .mli with the function face

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### Changes
+
+- [#60](https://github.com/bbatsov/neocaml/issues/60): Highlight function-typed `val` specifications in `.mli` files with the function face, matching how function `let` bindings are highlighted in implementations.
+
 ## 0.8.1 (2026-05-13)
 
 ### Bug fixes

--- a/neocaml.el
+++ b/neocaml.el
@@ -300,6 +300,16 @@ The return value is suitable for `treesit-font-lock-settings'."
      (field_expression ["="] @font-lock-keyword-face)
      (for_expression ["="] @font-lock-keyword-face))
 
+   ;; Upgrade function-typed `val' specifications (in .mli files) to the
+   ;; function face, mirroring how function `let' bindings are highlighted
+   ;; in implementations.  This overrides the generic `value_specification'
+   ;; rule above, so it lives in its own `:override' block under the same
+   ;; `definition' feature.
+   :language language
+   :feature 'definition
+   :override t
+   '((value_specification (value_name) @font-lock-function-name-face (function_type)))
+
    :language language
    :feature 'keyword
    `([,@neocaml-mode--keywords] @font-lock-keyword-face

--- a/test/neocaml-font-lock-test.el
+++ b/test/neocaml-font-lock-test.el
@@ -467,6 +467,18 @@
       ("val x : int"
        ("x" font-lock-variable-name-face)))
 
+    (when-fontifying-interface-it "fontifies function-typed val as a function"
+      ("val f : int -> int"
+       ("f" font-lock-function-name-face)))
+
+    (when-fontifying-interface-it "fontifies higher-order function-typed val as a function"
+      ("val f : (int -> int) -> int"
+       ("f" font-lock-function-name-face)))
+
+    (when-fontifying-interface-it "fontifies non-function val as a variable"
+      ("val x : int list"
+       ("x" font-lock-variable-name-face)))
+
     (when-fontifying-interface-it "fontifies : in val specification as keyword"
       ("val x : int"
        (7 7 font-lock-keyword-face)))


### PR DESCRIPTION
In interface files a `val` whose type is a function (has a top-level arrow) was painted with the variable face, same as any other value. This distinguishes them: function-typed `val` specs now get the function face, mirroring how function `let` bindings are already highlighted in implementations.

Detection is syntactic (the `val`'s type has a top-level `function_type`), so it matches the implementation side's approach and won't resolve function-typed aliases.

Addresses the first item in #60; the other two asks there (C-c C-a repositioning, ocamldoc rendering) need more thought and are left open.