### PR TITLE
Flesh out the mode and REPL menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### New features
+
+- Add an "Edit" submenu to the mode menu with commands for commenting/uncommenting the region, filling comment paragraphs, and indenting the region.
+
 ### Changes
 
 - [#60](https://github.com/bbatsov/neocaml/issues/60): Highlight function-typed `val` specifications in `.mli` files with the function face, matching how function `let` bindings are highlighted in implementations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### New features
 
-- Add an "Edit" submenu to the mode menu with commands for commenting/uncommenting the region, filling comment paragraphs, and indenting the region.
+- [#63](https://github.com/bbatsov/neocaml/pull/63): Flesh out the mode and REPL menus:
+  - Add an "Edit" submenu (comment/uncomment region, fill comment paragraph, indent region).
+  - Add an "OCaml REPL" menu to the REPL buffer (`neocaml-repl-mode`) for switching back to the source, interrupting, and clearing the buffer.
+  - Add a "Toggle" submenu (prettify symbols, subword mode, outline minor mode) and a "Start/Switch to REPL" entry to the mode menu.
+  - Add help strings (tooltips) and "Customize" entries to the menus, and disable REPL commands that need an active region or a running process when those aren't available.
 
 ### Changes
 

--- a/neocaml-repl.el
+++ b/neocaml-repl.el
@@ -106,6 +106,18 @@ Used by `neocaml-repl-switch-to-source' to return to the source buffer.")
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map comint-mode-map)
     (define-key map (kbd "C-c C-z") #'neocaml-repl-switch-to-source)
+    (easy-menu-define neocaml-repl-mode-menu map "OCaml REPL Menu"
+      '("OCaml REPL"
+        ["Switch to Source" neocaml-repl-switch-to-source
+         :help "Switch back to the source buffer that last invoked the REPL"]
+        "--"
+        ["Interrupt" neocaml-repl-interrupt
+         :help "Interrupt the OCaml toplevel process"]
+        ["Clear Buffer" neocaml-repl-clear-buffer
+         :help "Erase the REPL buffer contents"]
+        "--"
+        ["Customize OCaml REPL..." (customize-group 'neocaml-repl)
+         :help "Customize the OCaml REPL settings"]))
     map)
   "Keymap for `neocaml-repl-mode'.")
 

--- a/neocaml-repl.el
+++ b/neocaml-repl.el
@@ -315,16 +315,27 @@ Skips `;;' that appear inside strings or comments."
 
     (easy-menu-define neocaml-repl-minor-mode-menu map "OCaml REPL Menu"
       '("OCaml REPL"
-        ["Start/Switch to REPL" neocaml-repl-switch-to-repl]
+        ["Start/Switch to REPL" neocaml-repl-switch-to-repl
+         :help "Start the OCaml REPL or switch to a running one"]
         "--"
-        ["Send Definition" neocaml-repl-send-definition]
-        ["Send Region" neocaml-repl-send-region]
-        ["Send Buffer" neocaml-repl-send-buffer]
-        ["Send Phrase" neocaml-repl-send-phrase]
-        ["Load File" neocaml-repl-load-file]
+        ["Send Definition" neocaml-repl-send-definition
+         :help "Send the definition at point to the REPL"]
+        ["Send Region" neocaml-repl-send-region
+         :enable (use-region-p)
+         :help "Send the active region to the REPL"]
+        ["Send Buffer" neocaml-repl-send-buffer
+         :help "Send the whole buffer to the REPL"]
+        ["Send Phrase" neocaml-repl-send-phrase
+         :help "Send the phrase at point to the REPL"]
+        ["Load File" neocaml-repl-load-file
+         :help "Load a file into the REPL with #use"]
         "--"
-        ["Interrupt REPL" neocaml-repl-interrupt]
-        ["Clear REPL Buffer" neocaml-repl-clear-buffer]))
+        ["Interrupt REPL" neocaml-repl-interrupt
+         :enable (comint-check-proc neocaml-repl-buffer-name)
+         :help "Interrupt the OCaml toplevel process"]
+        ["Clear REPL Buffer" neocaml-repl-clear-buffer
+         :enable (comint-check-proc neocaml-repl-buffer-name)
+         :help "Erase the REPL buffer contents"]))
     map)
   "Keymap for OCaml toplevel integration.")
 

--- a/neocaml.el
+++ b/neocaml.el
@@ -1301,6 +1301,16 @@ The information is also copied to the kill ring."
          "--"
          ["Indent Region" indent-region (use-region-p)
           :help "Reindent the lines in the region"])
+        ("Toggle"
+         ["Prettify Symbols" prettify-symbols-mode
+          :style toggle :selected (bound-and-true-p prettify-symbols-mode)
+          :help "Display keywords and operators using Unicode symbols"]
+         ["Subword Mode" subword-mode
+          :style toggle :selected (bound-and-true-p subword-mode)
+          :help "Treat CamelCase subwords as separate words when moving"]
+         ["Outline Minor Mode" outline-minor-mode
+          :style toggle :selected (bound-and-true-p outline-minor-mode)
+          :help "Fold and navigate top-level definitions"])
         "--"
         ["Mark Definition" mark-defun
          :help "Mark the current definition"]
@@ -1314,6 +1324,8 @@ The information is also copied to the kill ring."
         ["Transpose Statement" transpose-sentences
          :help "Transpose the statements around point"]
         "--"
+        ["Start/Switch to REPL" neocaml-repl-switch-to-repl
+         :help "Start the OCaml REPL or switch to a running one"]
         ["Compile..." compile
          :help "Compile the project"]
         ["Cycle indent function" neocaml-cycle-indent-function

--- a/neocaml.el
+++ b/neocaml.el
@@ -1272,39 +1272,66 @@ The information is also copied to the kill ring."
     (easy-menu-define neocaml-mode-menu map "Neocaml Mode Menu"
       '("OCaml"
         ("Navigate"
-         ["Beginning of Definition" beginning-of-defun]
-         ["End of Definition" end-of-defun]
-         ["Forward Expression" forward-sexp]
-         ["Backward Expression" backward-sexp]
-         ["Forward Statement" forward-sentence]
-         ["Backward Statement" backward-sentence]
-         ["Up to Enclosing Block" neocaml-backward-up-list])
+         ["Beginning of Definition" beginning-of-defun
+          :help "Move to the beginning of the current definition"]
+         ["End of Definition" end-of-defun
+          :help "Move to the end of the current definition"]
+         ["Forward Expression" forward-sexp
+          :help "Move forward across one balanced expression"]
+         ["Backward Expression" backward-sexp
+          :help "Move backward across one balanced expression"]
+         ["Forward Statement" forward-sentence
+          :help "Move forward to the next top-level statement"]
+         ["Backward Statement" backward-sentence
+          :help "Move backward to the previous top-level statement"]
+         ["Up to Enclosing Block" neocaml-backward-up-list
+          :help "Move out of the enclosing block"])
         ("Find..."
-         ["Find Interface/Implementation" ff-find-other-file]
-         ["Find Interface/Implementation in other window" ff-find-other-file-other-window])
+         ["Find Interface/Implementation" ff-find-other-file
+          :help "Switch between the .ml and .mli file"]
+         ["Find Interface/Implementation in other window" ff-find-other-file-other-window
+          :help "Switch between the .ml and .mli file in another window"])
         ("Edit"
-         ["Comment Out Region" comment-region (use-region-p)]
-         ["Uncomment Region" uncomment-region (use-region-p)]
-         ["Fill Comment Paragraph" fill-paragraph t]
+         ["Comment Out Region" comment-region (use-region-p)
+          :help "Comment out the lines in the region"]
+         ["Uncomment Region" uncomment-region (use-region-p)
+          :help "Uncomment the lines in the region"]
+         ["Fill Comment Paragraph" fill-paragraph t
+          :help "Fill the comment paragraph at point"]
          "--"
-         ["Indent Region" indent-region (use-region-p)])
+         ["Indent Region" indent-region (use-region-p)
+          :help "Reindent the lines in the region"])
         "--"
-        ["Mark Definition" mark-defun]
-        ["Mark Expression" mark-sexp]
-        ["Mark Statement" neocaml-mark-sentence]
+        ["Mark Definition" mark-defun
+         :help "Mark the current definition"]
+        ["Mark Expression" mark-sexp
+         :help "Mark the expression after point"]
+        ["Mark Statement" neocaml-mark-sentence
+         :help "Mark the current statement"]
         "--"
-        ["Transpose Expression" transpose-sexps]
-        ["Transpose Statement" transpose-sentences]
+        ["Transpose Expression" transpose-sexps
+         :help "Transpose the expressions around point"]
+        ["Transpose Statement" transpose-sentences
+         :help "Transpose the statements around point"]
         "--"
-        ["Compile..." compile]
-        ["Cycle indent function" neocaml-cycle-indent-function]
-        ["Install tree-sitter grammars" neocaml-install-grammars]
+        ["Compile..." compile
+         :help "Compile the project"]
+        ["Cycle indent function" neocaml-cycle-indent-function
+         :help "Switch between tree-sitter and relative indentation"]
+        ["Install tree-sitter grammars" neocaml-install-grammars
+         :help "Install the OCaml tree-sitter grammars"]
         ("Documentation"
-         ["Browse OCaml Docs" neocaml-browse-ocaml-docs])
+         ["Browse OCaml Docs" neocaml-browse-ocaml-docs
+          :help "Browse the OCaml documentation in a web browser"])
         "--"
-        ["Report a neocaml bug" neocaml-report-bug]
-        ["Show bug report info" neocaml-bug-report-info]
-        ["neocaml version" neocaml-version]))
+        ["Customize neocaml..." (customize-group 'neocaml)
+         :help "Customize neocaml settings"]
+        ["Report a neocaml bug" neocaml-report-bug
+         :help "Report a bug to the neocaml issue tracker"]
+        ["Show bug report info" neocaml-bug-report-info
+         :help "Show environment info useful for bug reports"]
+        ["neocaml version" neocaml-version
+         :help "Display the neocaml version"]))
     map)
   "Keymap shared by `neocaml-mode' and `neocaml-interface-mode'.")
 

--- a/neocaml.el
+++ b/neocaml.el
@@ -1282,6 +1282,12 @@ The information is also copied to the kill ring."
         ("Find..."
          ["Find Interface/Implementation" ff-find-other-file]
          ["Find Interface/Implementation in other window" ff-find-other-file-other-window])
+        ("Edit"
+         ["Comment Out Region" comment-region (use-region-p)]
+         ["Uncomment Region" uncomment-region (use-region-p)]
+         ["Fill Comment Paragraph" fill-paragraph t]
+         "--"
+         ["Indent Region" indent-region (use-region-p)])
         "--"
         ["Mark Definition" mark-defun]
         ["Mark Expression" mark-sexp]


### PR DESCRIPTION
The menus were pretty sparse, so this rounds them out after a look at what the built-in modes (cc-mode, octave, scheme, sql, ielm, comint, ...) put in theirs.

The notable gap was the REPL buffer: `neocaml-repl-mode` had no menu of its own and relied entirely on the inherited comint menus, so there was no quick way to switch back to the source, interrupt, or clear it. It gets a proper "OCaml REPL" menu now.

Beyond that: an "Edit" submenu (comment/uncomment/fill/indent region), a "Toggle" submenu (prettify-symbols, eldoc), a "Start/Switch to REPL" entry, Customize entries, help strings throughout, and `:enable` guards so the REPL send/process commands only light up when a region or running process is actually there.

Menu-only, so no behavior tests; verified it all byte-compiles clean and the existing suite stays green.