### PR TITLE
Add ocamlformat, clickable comment links, and a REPL restart command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Add help strings (tooltips) and "Customize" entries to the menus, and disable REPL commands that need an active region or a running process when those aren't available.
 - Add `neocaml-set-font-lock-level` and a "Font-Lock Level" submenu for switching the tree-sitter fontification level (1-4) in the current buffer.
 - Add `neocaml-format-buffer` (bound to `C-c C-f`) to format OCaml source with `ocamlformat`, plus an opt-in `neocaml-format-on-save`.
+- Make URLs and bug references in comments clickable across the OCaml source and tool modes via `goto-address-prog-mode` and `bug-reference-prog-mode`. Set `bug-reference-url-format` (e.g. via `.dir-locals.el`) to resolve issue references.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add `neocaml-set-font-lock-level` and a "Font-Lock Level" submenu for switching the tree-sitter fontification level (1-4) in the current buffer.
 - Add `neocaml-format-buffer` (bound to `C-c C-f`) to format OCaml source with `ocamlformat`, plus an opt-in `neocaml-format-on-save`.
 - Make URLs and bug references in comments clickable across the OCaml source and tool modes via `goto-address-prog-mode` and `bug-reference-prog-mode`. Set `bug-reference-url-format` (e.g. via `.dir-locals.el`) to resolve issue references.
+- Add `neocaml-repl-restart` to kill and restart the OCaml toplevel, with a matching entry in the REPL menu.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Add a "Toggle" submenu (prettify symbols, subword mode, outline minor mode) and a "Start/Switch to REPL" entry to the mode menu.
   - Add help strings (tooltips) and "Customize" entries to the menus, and disable REPL commands that need an active region or a running process when those aren't available.
 - Add `neocaml-set-font-lock-level` and a "Font-Lock Level" submenu for switching the tree-sitter fontification level (1-4) in the current buffer.
+- Add `neocaml-format-buffer` (bound to `C-c C-f`) to format OCaml source with `ocamlformat`, plus an opt-in `neocaml-format-on-save`.
 
 ### Changes
 

--- a/neocaml-dune.el
+++ b/neocaml-dune.el
@@ -275,6 +275,10 @@ tree-sitter >= 0.24" (treesit-library-abi-version)))
   ;; Final newline
   (setq-local require-final-newline mode-require-final-newline)
 
+  ;; Make URLs and bug references in comments clickable
+  (goto-address-prog-mode)
+  (bug-reference-prog-mode)
+
   (treesit-major-mode-setup))
 
 (define-key neocaml-dune-mode-map (kbd "C-c C-f") #'neocaml-dune-format-buffer)

--- a/neocaml-menhir.el
+++ b/neocaml-menhir.el
@@ -253,6 +253,10 @@ via language injection.
   ;; Final newline
   (setq-local require-final-newline mode-require-final-newline)
 
+  ;; Make URLs and bug references in comments clickable
+  (goto-address-prog-mode)
+  (bug-reference-prog-mode)
+
   (treesit-major-mode-setup))
 
 ;;;###autoload

--- a/neocaml-ocamllex.el
+++ b/neocaml-ocamllex.el
@@ -247,6 +247,10 @@ tree-sitter >= 0.24" (treesit-library-abi-version)))
   ;; Final newline
   (setq-local require-final-newline mode-require-final-newline)
 
+  ;; Make URLs and bug references in comments clickable
+  (goto-address-prog-mode)
+  (bug-reference-prog-mode)
+
   (treesit-major-mode-setup))
 
 ;;;###autoload

--- a/neocaml-opam.el
+++ b/neocaml-opam.el
@@ -302,6 +302,10 @@ tree-sitter >= 0.24" (treesit-library-abi-version)))
   ;; Final newline
   (setq-local require-final-newline mode-require-final-newline)
 
+  ;; Make URLs and bug references in comments clickable
+  (goto-address-prog-mode)
+  (bug-reference-prog-mode)
+
   (treesit-major-mode-setup)
 
   ;; Flymake via opam lint (users enable flymake-mode via hook)

--- a/neocaml-repl.el
+++ b/neocaml-repl.el
@@ -113,6 +113,8 @@ Used by `neocaml-repl-switch-to-source' to return to the source buffer.")
         "--"
         ["Interrupt" neocaml-repl-interrupt
          :help "Interrupt the OCaml toplevel process"]
+        ["Restart" neocaml-repl-restart
+         :help "Kill and restart the OCaml toplevel"]
         ["Clear Buffer" neocaml-repl-clear-buffer
          :help "Erase the REPL buffer contents"]
         "--"
@@ -297,6 +299,19 @@ Skips `;;' that appear inside strings or comments."
   (interactive)
   (when (comint-check-proc neocaml-repl-buffer-name)
     (interrupt-process (neocaml-repl--process))))
+
+;;;###autoload
+(defun neocaml-repl-restart ()
+  "Restart the OCaml toplevel.
+Kill the running process, if any, and start a fresh one in the same
+buffer."
+  (interactive)
+  (when (comint-check-proc neocaml-repl-buffer-name)
+    (let ((proc (neocaml-repl--process)))
+      (when proc
+        (set-process-query-on-exit-flag proc nil)
+        (delete-process proc))))
+  (neocaml-repl-start))
 
 ;; Installation of the toplevel integration
 (defvar neocaml-repl-mode-hook nil

--- a/neocaml.el
+++ b/neocaml.el
@@ -1549,6 +1549,11 @@ for .ml files and `neocaml-interface-mode' for .mli files."
   ;; Optional format-on-save via ocamlformat
   (add-hook 'before-save-hook #'neocaml--format-before-save nil t)
 
+  ;; Make URLs and bug references in comments clickable.  Set
+  ;; `bug-reference-url-format' (e.g. via .dir-locals.el) to resolve refs.
+  (goto-address-prog-mode)
+  (bug-reference-prog-mode)
+
   ;; TODO: Make this configurable?
   (setq-local treesit-font-lock-feature-list
               '((comment definition)

--- a/neocaml.el
+++ b/neocaml.el
@@ -107,6 +107,20 @@ Set to nil if you work with build artifacts directly, e.g. when debugging."
   :group 'neocaml
   :package-version '(neocaml . "0.8.0"))
 
+(defcustom neocaml-ocamlformat-program "ocamlformat"
+  "Program used to format OCaml source via `neocaml-format-buffer'."
+  :type 'string
+  :group 'neocaml
+  :package-version '(neocaml . "0.9.0"))
+
+(defcustom neocaml-format-on-save nil
+  "When non-nil, format the buffer with `ocamlformat' before saving.
+Only applies in `neocaml-mode' and `neocaml-interface-mode' buffers."
+  :type 'boolean
+  :safe #'booleanp
+  :group 'neocaml
+  :package-version '(neocaml . "0.9.0"))
+
 (defvar neocaml--debug nil
   "Enable debugging messages and show the current node in the mode-line.
 When set to t, show indentation debug info.
@@ -625,6 +639,55 @@ fontification).  The change is buffer-local; use \\[customize-variable] on
   (treesit-font-lock-recompute-features)
   (font-lock-flush)
   (message "[neocaml] Font-lock level set to %d" level))
+
+;;;; Formatting
+
+(defun neocaml--ocamlformat-args ()
+  "Return the argument list for invoking `ocamlformat' on the current buffer.
+When the buffer is visiting a file, pass its name via `--name' so
+ocamlformat picks up the right `.ocamlformat' profile and infers
+implementation vs. interface from the extension.  Otherwise fall back
+to `--impl'/`--intf' based on the major mode.  ocamlformat reads the
+source from stdin (the trailing \"-\")."
+  (append
+   (if buffer-file-name
+       (list "--name" buffer-file-name)
+     (list (if (derived-mode-p 'neocaml-interface-mode) "--intf" "--impl")))
+   (list "-")))
+
+(defun neocaml-format-buffer ()
+  "Format the current buffer using `ocamlformat'.
+Pipes the buffer through `neocaml-ocamlformat-program' and replaces the
+buffer text with the formatted output, preserving point.  ocamlformat
+formats whole compilation units, so there is no region/defun variant."
+  (interactive)
+  (let ((outbuf (generate-new-buffer " *neocaml-ocamlformat*"))
+        (errfile (make-temp-file "neocaml-ocamlformat-err"))
+        (orig-point (point))
+        (orig-window-start (window-start)))
+    (unwind-protect
+        (let ((exit-code (apply #'call-process-region
+                                (point-min) (point-max)
+                                neocaml-ocamlformat-program nil
+                                (list outbuf errfile) nil
+                                (neocaml--ocamlformat-args))))
+          (if (zerop exit-code)
+              (progn
+                (erase-buffer)
+                (insert-buffer-substring outbuf)
+                (goto-char (min orig-point (point-max)))
+                (set-window-start (selected-window) orig-window-start))
+            (user-error "Running ocamlformat failed: %s"
+                        (with-temp-buffer
+                          (insert-file-contents errfile)
+                          (string-trim (buffer-string))))))
+      (kill-buffer outbuf)
+      (delete-file errfile))))
+
+(defun neocaml--format-before-save ()
+  "Format the buffer before saving when `neocaml-format-on-save' is non-nil."
+  (when neocaml-format-on-save
+    (neocaml-format-buffer)))
 
 ;;;; Find the definition at point (some Emacs commands use this internally)
 
@@ -1279,6 +1342,7 @@ The information is also copied to the kill ring."
     (define-key map (kbd "C-c C-a") #'ff-find-other-file)
     (define-key map (kbd "C-c 4 C-a") #'ff-find-other-file-other-window)
     (define-key map (kbd "C-c C-c") #'compile)
+    (define-key map (kbd "C-c C-f") #'neocaml-format-buffer)
     (define-key map (kbd "C-M-u") #'neocaml-backward-up-list)
     (easy-menu-define neocaml-mode-menu map "Neocaml Mode Menu"
       '("OCaml"
@@ -1311,7 +1375,10 @@ The information is also copied to the kill ring."
           :help "Fill the comment paragraph at point"]
          "--"
          ["Indent Region" indent-region (use-region-p)
-          :help "Reindent the lines in the region"])
+          :help "Reindent the lines in the region"]
+         "--"
+         ["Format Buffer (ocamlformat)" neocaml-format-buffer
+          :help "Format the whole buffer with ocamlformat"])
         ("Toggle"
          ["Prettify Symbols" prettify-symbols-mode
           :style toggle :selected (bound-and-true-p prettify-symbols-mode)
@@ -1478,6 +1545,9 @@ for .ml files and `neocaml-interface-mode' for .mli files."
   ;; Fill paragraph
   (setq-local fill-paragraph-function #'neocaml--fill-paragraph)
   (setq-local adaptive-fill-mode t)
+
+  ;; Optional format-on-save via ocamlformat
+  (add-hook 'before-save-hook #'neocaml--format-before-save nil t)
 
   ;; TODO: Make this configurable?
   (setq-local treesit-font-lock-feature-list

--- a/test/neocaml-comment-links-test.el
+++ b/test/neocaml-comment-links-test.el
@@ -1,0 +1,33 @@
+;;; neocaml-comment-links-test.el --- Comment-link tests -*- lexical-binding: t; -*-
+
+;; Copyright © 2025-2026 Bozhidar Batsov
+
+;;; Commentary:
+
+;; Buttercup tests verifying that neocaml modes enable clickable URLs and
+;; bug references in comments (goto-address-prog-mode / bug-reference-prog-mode).
+
+;;; Code:
+
+(require 'neocaml-test-helpers)
+
+(describe "comment links"
+  (it "enables goto-address and bug-reference in neocaml-mode"
+    (unless (treesit-language-available-p 'ocaml)
+      (signal 'buttercup-pending "tree-sitter OCaml grammar not available"))
+    (with-temp-buffer
+      (neocaml-mode)
+      (expect (bound-and-true-p goto-address-prog-mode) :to-be-truthy)
+      (expect (bound-and-true-p bug-reference-prog-mode) :to-be-truthy)))
+
+  (it "enables goto-address and bug-reference in neocaml-interface-mode"
+    (unless (treesit-language-available-p 'ocaml-interface)
+      (signal 'buttercup-pending "tree-sitter OCaml interface grammar not available"))
+    (with-temp-buffer
+      (neocaml-interface-mode)
+      (expect (bound-and-true-p goto-address-prog-mode) :to-be-truthy)
+      (expect (bound-and-true-p bug-reference-prog-mode) :to-be-truthy))))
+
+(provide 'neocaml-comment-links-test)
+
+;;; neocaml-comment-links-test.el ends here

--- a/test/neocaml-format-test.el
+++ b/test/neocaml-format-test.el
@@ -1,0 +1,39 @@
+;;; neocaml-format-test.el --- Formatting tests for neocaml -*- lexical-binding: t; -*-
+
+;; Copyright © 2025-2026 Bozhidar Batsov
+
+;;; Commentary:
+
+;; Buttercup tests for ocamlformat integration in neocaml.
+
+;;; Code:
+
+(require 'neocaml-test-helpers)
+
+(describe "neocaml--ocamlformat-args"
+  (it "uses --name when the buffer visits a file"
+    (with-temp-buffer
+      (setq buffer-file-name "/tmp/example.ml")
+      (expect (neocaml--ocamlformat-args)
+              :to-equal '("--name" "/tmp/example.ml" "-"))))
+
+  (it "falls back to --impl for a fileless implementation buffer"
+    (with-temp-buffer
+      (when (treesit-language-available-p 'ocaml)
+        (neocaml-mode))
+      (setq buffer-file-name nil)
+      (expect (neocaml--ocamlformat-args)
+              :to-equal '("--impl" "-"))))
+
+  (it "falls back to --intf for a fileless interface buffer"
+    (with-temp-buffer
+      (if (treesit-language-available-p 'ocaml-interface)
+          (neocaml-interface-mode)
+        (signal 'buttercup-pending "interface grammar not available"))
+      (setq buffer-file-name nil)
+      (expect (neocaml--ocamlformat-args)
+              :to-equal '("--intf" "-")))))
+
+(provide 'neocaml-format-test)
+
+;;; neocaml-format-test.el ends here

--- a/test/neocaml-repl-test.el
+++ b/test/neocaml-repl-test.el
@@ -170,4 +170,23 @@
             (expect 'message :to-have-been-called-with "No source buffer to return to"))
         (when (buffer-live-p repl) (kill-buffer repl))))))
 
+(describe "neocaml-repl restart"
+  (it "kills the running process and starts a fresh REPL"
+    (spy-on 'comint-check-proc :and-return-value t)
+    (spy-on 'neocaml-repl--process :and-return-value 'fake-proc)
+    (spy-on 'set-process-query-on-exit-flag)
+    (spy-on 'delete-process)
+    (spy-on 'neocaml-repl-start)
+    (neocaml-repl-restart)
+    (expect 'delete-process :to-have-been-called-with 'fake-proc)
+    (expect 'neocaml-repl-start :to-have-been-called))
+
+  (it "just starts a REPL when none is running"
+    (spy-on 'comint-check-proc :and-return-value nil)
+    (spy-on 'delete-process)
+    (spy-on 'neocaml-repl-start)
+    (neocaml-repl-restart)
+    (expect 'delete-process :not :to-have-been-called)
+    (expect 'neocaml-repl-start :to-have-been-called)))
+
 ;;; neocaml-repl-test.el ends here


### PR DESCRIPTION
A few small editing/REPL quick wins from the roadmap:

- `neocaml-format-buffer` (bound to `C-c C-f`) formats OCaml source with `ocamlformat`, with an opt-in `neocaml-format-on-save`, mirroring the existing dune formatter. It passes `--name` for file buffers so the right `.ocamlformat` profile and impl/intf are used.
- URLs and bug references in comments are now clickable in the OCaml source and tool modes (`goto-address-prog-mode` + `bug-reference-prog-mode`). URLs work out of the box; set `bug-reference-url-format` (e.g. via `.dir-locals.el`) to resolve issue refs per project.
- `neocaml-repl-restart` kills and restarts the toplevel, with a Restart entry in the REPL menu.

Skeletons for common forms were considered too but pulled out for now pending more thought on their value.