### PR TITLE
REPL: add send-phrase-and-step and a #require helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#65](https://github.com/bbatsov/neocaml/pull/65): Add `neocaml-format-buffer` (bound to `C-c C-f`) to format OCaml source with `ocamlformat`, plus an opt-in `neocaml-format-on-save`.
 - [#65](https://github.com/bbatsov/neocaml/pull/65): Make URLs and bug references in comments clickable across the OCaml source and tool modes via `goto-address-prog-mode` and `bug-reference-prog-mode`. Set `bug-reference-url-format` (e.g. via `.dir-locals.el`) to resolve issue references.
 - [#65](https://github.com/bbatsov/neocaml/pull/65): Add `neocaml-repl-restart` to kill and restart the OCaml toplevel, with a matching entry in the REPL menu.
+- [#68](https://github.com/bbatsov/neocaml/pull/68): Add `neocaml-repl-send-phrase-and-step` (bound to `C-c C-n`), which sends the phrase at point to the REPL and advances to the next one, and `neocaml-repl-require` for loading a findlib package via `#require`.
 
 ### Bug fixes
 

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -45,6 +45,7 @@ The following keybindings are available when `neocaml-repl-minor-mode` is active
 | `C-c C-b` | `neocaml-repl-send-buffer` | Send the entire buffer to the REPL |
 | `C-c C-l` | `neocaml-repl-load-file` | Load the current file into the REPL via `#use` |
 | `C-c C-p` | `neocaml-repl-send-phrase` | Send the current phrase (code up to next `;;`) to the REPL |
+| `C-c C-n` | `neocaml-repl-send-phrase-and-step` | Send the current phrase, then move to the next one |
 | `C-c C-i` | `neocaml-repl-interrupt` | Interrupt the current evaluation in the REPL |
 | `C-c C-k` | `neocaml-repl-clear-buffer` | Clear the REPL buffer |
 
@@ -52,9 +53,17 @@ The following keybindings are available when `neocaml-repl-minor-mode` is active
     In the REPL buffer itself, `C-c C-z` switches back to the source
     buffer you came from, so you can quickly bounce between source and REPL.
 
+`C-c C-n` (`neocaml-repl-send-phrase-and-step`) is handy for working
+through a buffer: it sends the phrase at point and then advances to the
+start of the next one, so you can evaluate a file phrase by phrase with
+repeated presses.
+
+`M-x neocaml-repl-require` loads a findlib package into the REPL via
+`#require` (the toplevel needs findlib, e.g. via `topfind` or utop).
+
 `M-x neocaml-repl-restart` kills the running toplevel and starts a fresh
-one in the same buffer. It, along with the commands above, is also
-available from the "OCaml REPL" menu in the REPL buffer.
+one in the same buffer. These, along with the commands above, are also
+available from the "OCaml REPL" menu.
 
 The REPL buffer also enables `compilation-shell-minor-mode`, so
 error locations in REPL output are clickable and navigable with

--- a/neocaml-repl.el
+++ b/neocaml-repl.el
@@ -258,14 +258,31 @@ after the delimiter (forward) or before it (backward), or nil."
             (setq found (if (> direction 0) (point) (match-beginning 0)))))))
     found))
 
+(defun neocaml-repl--phrase-bounds ()
+  "Return (START . END) of the phrase at point, bounded by `;;'.
+START falls back to `point-min' and END to `point-max'."
+  (cons (or (neocaml-repl--search-phrase-delimiter -1) (point-min))
+        (or (neocaml-repl--search-phrase-delimiter 1) (point-max))))
+
 ;;;###autoload
 (defun neocaml-repl-send-phrase ()
   "Send the current phrase (code between `;;' delimiters) to the OCaml REPL.
 Skips `;;' that appear inside strings or comments."
   (interactive)
-  (let ((end (or (neocaml-repl--search-phrase-delimiter 1) (point-max)))
-        (start (or (neocaml-repl--search-phrase-delimiter -1) (point-min))))
-    (neocaml-repl-send-region start end)))
+  (let ((bounds (neocaml-repl--phrase-bounds)))
+    (neocaml-repl-send-region (car bounds) (cdr bounds))))
+
+;;;###autoload
+(defun neocaml-repl-send-phrase-and-step ()
+  "Send the phrase at point to the OCaml REPL, then move to the next phrase.
+Like `neocaml-repl-send-phrase', but advances point past the closing
+`;;' to the start of the following phrase, so repeated invocations walk
+through the buffer."
+  (interactive)
+  (let ((bounds (neocaml-repl--phrase-bounds)))
+    (neocaml-repl-send-region (car bounds) (cdr bounds))
+    (goto-char (cdr bounds))
+    (skip-chars-forward " \t\n")))
 
 (defun neocaml-repl--process ()
   "Return the REPL process, or nil if not running."
@@ -285,6 +302,15 @@ Skips `;;' that appear inside strings or comments."
   (neocaml-repl--ensure-repl-running)
   (neocaml-repl--input-sender (neocaml-repl--process)
                                (format "#use %S" file)))
+
+;;;###autoload
+(defun neocaml-repl-require (package)
+  "Load the findlib PACKAGE into the OCaml REPL via the `#require' directive.
+This needs the toplevel to have findlib loaded (e.g. via topfind or utop)."
+  (interactive (list (read-string "Require package: ")))
+  (neocaml-repl--ensure-repl-running)
+  (neocaml-repl--input-sender (neocaml-repl--process)
+                               (format "#require %S" package)))
 
 (defun neocaml-repl-clear-buffer ()
   "Clear the OCaml REPL buffer."
@@ -324,6 +350,7 @@ buffer."
     (define-key map (kbd "C-c C-r") #'neocaml-repl-send-region)
     (define-key map (kbd "C-c C-b") #'neocaml-repl-send-buffer)
     (define-key map (kbd "C-c C-p") #'neocaml-repl-send-phrase)
+    (define-key map (kbd "C-c C-n") #'neocaml-repl-send-phrase-and-step)
     (define-key map (kbd "C-c C-l") #'neocaml-repl-load-file)
     (define-key map (kbd "C-c C-i") #'neocaml-repl-interrupt)
     (define-key map (kbd "C-c C-k") #'neocaml-repl-clear-buffer)
@@ -342,8 +369,12 @@ buffer."
          :help "Send the whole buffer to the REPL"]
         ["Send Phrase" neocaml-repl-send-phrase
          :help "Send the phrase at point to the REPL"]
+        ["Send Phrase and Step" neocaml-repl-send-phrase-and-step
+         :help "Send the phrase at point, then move to the next phrase"]
         ["Load File" neocaml-repl-load-file
          :help "Load a file into the REPL with #use"]
+        ["Require Package..." neocaml-repl-require
+         :help "Load a findlib package into the REPL with #require"]
         "--"
         ["Interrupt REPL" neocaml-repl-interrupt
          :enable (comint-check-proc neocaml-repl-buffer-name)

--- a/test/neocaml-repl-test.el
+++ b/test/neocaml-repl-test.el
@@ -189,4 +189,31 @@
     (expect 'delete-process :not :to-have-been-called)
     (expect 'neocaml-repl-start :to-have-been-called)))
 
+(describe "neocaml-repl send-phrase-and-step"
+  (before-all
+    (unless (treesit-language-available-p 'ocaml)
+      (signal 'buttercup-pending "tree-sitter OCaml grammar not available")))
+
+  (it "sends the current phrase and moves to the next one"
+    (with-neocaml-buffer "let x = 1;;\nlet y = 2;;\n"
+      (goto-char (point-min))
+      (let (sent)
+        (spy-on 'neocaml-repl-send-region :and-call-fake
+                (lambda (s e) (setq sent (string-trim
+                                          (buffer-substring-no-properties s e)))))
+        (neocaml-repl-send-phrase-and-step)
+        (expect sent :to-match "let x = 1")
+        ;; point should now sit at the start of the second phrase
+        (expect (looking-at "let y") :to-be-truthy)))))
+
+(describe "neocaml-repl require"
+  (it "sends a #require directive for the given package"
+    (let (sent)
+      (spy-on 'neocaml-repl--ensure-repl-running)
+      (spy-on 'neocaml-repl--process :and-return-value 'proc)
+      (spy-on 'neocaml-repl--input-sender :and-call-fake
+              (lambda (_proc input) (setq sent input)))
+      (neocaml-repl-require "lwt")
+      (expect sent :to-equal "#require \"lwt\""))))
+
 ;;; neocaml-repl-test.el ends here


### PR DESCRIPTION
First increment of roadmap #2 (smarter REPL).

- `neocaml-repl-send-phrase-and-step` (bound to `C-c C-n`) sends the phrase at point and then advances to the start of the next phrase, so you can evaluate a buffer phrase by phrase with repeated presses.
- `neocaml-repl-require` loads a findlib package via `#require` (mirrors the existing `#use` helper).

Both are wired into the REPL minor-mode menu, with tests and docs. More REPL improvements (completion, result handling, toplevel switching) are tracked as later increments.

Note: the `snapshot` CI job is expected to fail (the known upstream Emacs-master regression, #67) and is non-blocking; 29.4/30.1 should be green.