### PR TITLE
Give each project its own dedicated REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#65](https://github.com/bbatsov/neocaml/pull/65): Make URLs and bug references in comments clickable across the OCaml source and tool modes via `goto-address-prog-mode` and `bug-reference-prog-mode`. Set `bug-reference-url-format` (e.g. via `.dir-locals.el`) to resolve issue references.
 - [#65](https://github.com/bbatsov/neocaml/pull/65): Add `neocaml-repl-restart` to kill and restart the OCaml toplevel, with a matching entry in the REPL menu.
 - [#68](https://github.com/bbatsov/neocaml/pull/68): Add `neocaml-repl-send-phrase-and-step` (bound to `C-c C-n`), which sends the phrase at point to the REPL and advances to the next one, and `neocaml-repl-require` for loading a findlib package via `#require`.
+- [#69](https://github.com/bbatsov/neocaml/pull/69): Give each project its own dedicated REPL. The REPL buffer is now named per project (e.g. `*OCaml: myproject*`, derived from `neocaml-repl-buffer-name`), and the send commands route to the current buffer's project REPL, so multiple projects can run side by side. This also fixes `neocaml-dune-utop` so the send commands reach its toplevel.
 
 ### Bug fixes
 

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -69,6 +69,20 @@ The REPL buffer also enables `compilation-shell-minor-mode`, so
 error locations in REPL output are clickable and navigable with
 `next-error` / `previous-error`.
 
+## Per-project REPLs
+
+Each project gets its own dedicated REPL. When you start or send to a
+REPL from a source file, neocaml derives the project (via `project.el`,
+falling back to the directory containing a `dune-project`) and routes to
+a per-project buffer named after `neocaml-repl-buffer-name` plus the
+project, e.g. `*OCaml: myproject*`. Files outside any project share the
+base `*OCaml*` buffer.
+
+This means you can have several OCaml projects open at once, each with
+its own toplevel, and the send commands always reach the right one. It
+also means `M-x neocaml-dune-utop` (see below) and the regular send
+commands target the same per-project REPL.
+
 ## Input Syntax Highlighting
 
 By default, code you type in the REPL is fontified using tree-sitter
@@ -111,7 +125,8 @@ You can customize the OCaml REPL integration with the following variables:
 ;; preserve it when adding your own flags:
 (setq neocaml-repl-program-args '("-nopromptcont" "-short-paths" "-color=never"))
 
-;; Change the REPL buffer name (default: "*OCaml*")
+;; Change the base REPL buffer name (default: "*OCaml*").  Per-project
+;; REPLs derive their name from this, e.g. "*OCaml: myproject*".
 (setq neocaml-repl-buffer-name "*OCaml-REPL*")
 ```
 

--- a/neocaml-dune-interaction.el
+++ b/neocaml-dune-interaction.el
@@ -164,14 +164,15 @@ Launches utop with the project's libraries loaded, using the full
 REPL interaction (send region, send definition, etc.)."
   (interactive)
   (require 'neocaml-repl)
+  ;; Bind `default-directory' to the project root so the REPL is named (and
+  ;; routed) per project, and source files in the project send to it.
   (let* ((default-directory (neocaml-dune--project-root))
          (program (if neocaml-dune-use-opam-exec "opam" neocaml-dune-program))
          (args (if neocaml-dune-use-opam-exec
                    (list "exec" "--" neocaml-dune-program "utop" ".")
                  (list "utop" ".")))
          (neocaml-repl-program-name program)
-         (neocaml-repl-program-args args)
-         (neocaml-repl-buffer-name "*OCaml-dune-utop*"))
+         (neocaml-repl-program-args args))
     (neocaml-repl-switch-to-repl)))
 
 (defvar neocaml-dune--command-history nil

--- a/neocaml-repl.el
+++ b/neocaml-repl.el
@@ -102,6 +102,37 @@ Matches both the standard \"# \" prompt and utop's \"utop # \" / \"utop[0] # \".
   "Source buffer from which the REPL was last invoked.
 Used by `neocaml-repl-switch-to-source' to return to the source buffer.")
 
+;;;; Per-project REPL buffers
+;;
+;; Each project gets its own dedicated REPL, so source files send to the
+;; toplevel for their project.  The buffer name is derived from
+;; `neocaml-repl-buffer-name' plus the project identifier; buffers outside
+;; any project share the base name.
+
+(defun neocaml-repl--project-id ()
+  "Return a short identifier for the current buffer's project, or nil.
+Uses `project.el' when available, falling back to the directory that
+contains a `dune-project' file."
+  (when-let* ((root (or (and (fboundp 'project-current)
+                             (when-let* ((proj (project-current)))
+                               (project-root proj)))
+                        (locate-dominating-file default-directory "dune-project"))))
+    (file-name-nondirectory (directory-file-name root))))
+
+(defun neocaml-repl--buffer ()
+  "Return the name of the REPL buffer for the current context.
+In a REPL buffer, that is the buffer itself.  In a source buffer, it is
+the per-project REPL derived from `neocaml-repl-buffer-name' and the
+project identifier (or the base name when there is no project)."
+  (cond
+   ((derived-mode-p 'neocaml-repl-mode) (buffer-name))
+   ((neocaml-repl--project-id)
+    (let ((base (if (string-suffix-p "*" neocaml-repl-buffer-name)
+                    (substring neocaml-repl-buffer-name 0 -1)
+                  neocaml-repl-buffer-name)))
+      (format "%s: %s*" base (neocaml-repl--project-id))))
+   (t neocaml-repl-buffer-name)))
+
 (defvar neocaml-repl-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map comint-mode-map)
@@ -186,17 +217,18 @@ to avoid false positives from `;;' inside strings or comments."
 
 ;;;###autoload
 (defun neocaml-repl-start ()
-  "Start an OCaml toplevel process in a new buffer.
-If a process is already running, switch to its buffer."
+  "Start an OCaml toplevel for the current buffer's project.
+If a REPL for the project is already running, switch to its buffer."
   (interactive)
-  (if (comint-check-proc neocaml-repl-buffer-name)
-      (pop-to-buffer neocaml-repl-buffer-name)
-    (let* ((cmdlist (append (list neocaml-repl-program-name) neocaml-repl-program-args))
-           (buffer (apply #'make-comint-in-buffer "OCaml" neocaml-repl-buffer-name
-                         (car cmdlist) nil (cdr cmdlist))))
-      (with-current-buffer buffer
-        (neocaml-repl-mode))
-      (pop-to-buffer buffer))))
+  (let ((bufname (neocaml-repl--buffer)))
+    (if (comint-check-proc bufname)
+        (pop-to-buffer bufname)
+      (let* ((cmdlist (append (list neocaml-repl-program-name) neocaml-repl-program-args))
+             (buffer (apply #'make-comint-in-buffer "OCaml" bufname
+                            (car cmdlist) nil (cdr cmdlist))))
+        (with-current-buffer buffer
+          (neocaml-repl-mode))
+        (pop-to-buffer buffer)))))
 
 (defun neocaml-repl-switch-to-source ()
   "Switch from the REPL back to the source buffer that last invoked it."
@@ -212,11 +244,12 @@ If a process is already running, switch to its buffer."
 If a REPL is already running, switch to it; otherwise start a new one.
 Use \\[neocaml-repl-switch-to-source] in the REPL to return."
   (interactive)
-  (let ((source (current-buffer)))
-    (if (comint-check-proc neocaml-repl-buffer-name)
-        (pop-to-buffer neocaml-repl-buffer-name)
+  (let ((source (current-buffer))
+        (bufname (neocaml-repl--buffer)))
+    (if (comint-check-proc bufname)
+        (pop-to-buffer bufname)
       (neocaml-repl-start))
-    (with-current-buffer neocaml-repl-buffer-name
+    (with-current-buffer bufname
       (setq neocaml-repl--source-buffer source))))
 
 ;;;###autoload
@@ -285,12 +318,12 @@ through the buffer."
     (skip-chars-forward " \t\n")))
 
 (defun neocaml-repl--process ()
-  "Return the REPL process, or nil if not running."
-  (get-buffer-process neocaml-repl-buffer-name))
+  "Return the REPL process for the current context, or nil if not running."
+  (get-buffer-process (neocaml-repl--buffer)))
 
 (defun neocaml-repl--ensure-repl-running ()
-  "Start an OCaml REPL if one is not already running."
-  (unless (comint-check-proc neocaml-repl-buffer-name)
+  "Start a REPL for the current buffer's project if one is not running."
+  (unless (comint-check-proc (neocaml-repl--buffer))
     (neocaml-repl-start)))
 
 ;;;###autoload
@@ -313,26 +346,26 @@ This needs the toplevel to have findlib loaded (e.g. via topfind or utop)."
                                (format "#require %S" package)))
 
 (defun neocaml-repl-clear-buffer ()
-  "Clear the OCaml REPL buffer."
+  "Clear the OCaml REPL buffer for the current context."
   (interactive)
-  (with-current-buffer neocaml-repl-buffer-name
+  (with-current-buffer (neocaml-repl--buffer)
     (let ((inhibit-read-only t))
       (erase-buffer)
       (comint-send-input))))
 
 (defun neocaml-repl-interrupt ()
-  "Interrupt the OCaml REPL process."
+  "Interrupt the OCaml REPL process for the current context."
   (interactive)
-  (when (comint-check-proc neocaml-repl-buffer-name)
+  (when (comint-check-proc (neocaml-repl--buffer))
     (interrupt-process (neocaml-repl--process))))
 
 ;;;###autoload
 (defun neocaml-repl-restart ()
-  "Restart the OCaml toplevel.
+  "Restart the OCaml toplevel for the current buffer's project.
 Kill the running process, if any, and start a fresh one in the same
 buffer."
   (interactive)
-  (when (comint-check-proc neocaml-repl-buffer-name)
+  (when (comint-check-proc (neocaml-repl--buffer))
     (let ((proc (neocaml-repl--process)))
       (when proc
         (set-process-query-on-exit-flag proc nil)
@@ -377,10 +410,10 @@ buffer."
          :help "Load a findlib package into the REPL with #require"]
         "--"
         ["Interrupt REPL" neocaml-repl-interrupt
-         :enable (comint-check-proc neocaml-repl-buffer-name)
+         :enable (comint-check-proc (neocaml-repl--buffer))
          :help "Interrupt the OCaml toplevel process"]
         ["Clear REPL Buffer" neocaml-repl-clear-buffer
-         :enable (comint-check-proc neocaml-repl-buffer-name)
+         :enable (comint-check-proc (neocaml-repl--buffer))
          :help "Erase the REPL buffer contents"]))
     map)
   "Keymap for OCaml toplevel integration.")

--- a/test/neocaml-repl-test.el
+++ b/test/neocaml-repl-test.el
@@ -112,6 +112,7 @@
           (repl (get-buffer-create neocaml-repl-buffer-name)))
       (unwind-protect
           (with-current-buffer source
+            (spy-on 'neocaml-repl--buffer :and-return-value neocaml-repl-buffer-name)
             (spy-on 'comint-check-proc :and-return-value t)
             (spy-on 'pop-to-buffer)
             (neocaml-repl-switch-to-repl)
@@ -126,6 +127,7 @@
           (repl (get-buffer-create neocaml-repl-buffer-name)))
       (unwind-protect
           (with-current-buffer source
+            (spy-on 'neocaml-repl--buffer :and-return-value neocaml-repl-buffer-name)
             (spy-on 'comint-check-proc :and-return-value nil)
             (spy-on 'neocaml-repl-start)
             (neocaml-repl-switch-to-repl)
@@ -205,6 +207,31 @@
         (expect sent :to-match "let x = 1")
         ;; point should now sit at the start of the second phrase
         (expect (looking-at "let y") :to-be-truthy)))))
+
+(describe "neocaml-repl per-project buffer name"
+  (it "derives a per-project name from the base name"
+    (spy-on 'neocaml-repl--project-id :and-return-value "myproj")
+    (let ((neocaml-repl-buffer-name "*OCaml*"))
+      (with-temp-buffer
+        (expect (neocaml-repl--buffer) :to-equal "*OCaml: myproj*"))))
+
+  (it "falls back to the base name outside a project"
+    (spy-on 'neocaml-repl--project-id :and-return-value nil)
+    (let ((neocaml-repl-buffer-name "*OCaml*"))
+      (with-temp-buffer
+        (expect (neocaml-repl--buffer) :to-equal "*OCaml*"))))
+
+  (it "honors a customized base name"
+    (spy-on 'neocaml-repl--project-id :and-return-value "p")
+    (let ((neocaml-repl-buffer-name "*ocaml-repl*"))
+      (with-temp-buffer
+        (expect (neocaml-repl--buffer) :to-equal "*ocaml-repl: p*"))))
+
+  (it "targets the current buffer when inside a REPL buffer"
+    (with-temp-buffer
+      (rename-buffer "*OCaml: other*" t)
+      (setq major-mode 'neocaml-repl-mode)
+      (expect (neocaml-repl--buffer) :to-equal (buffer-name)))))
 
 (describe "neocaml-repl require"
   (it "sends a #require directive for the given package"


### PR DESCRIPTION
Part of roadmap #2 (smarter REPL), inspired by how `inf-clojure` resolves which process a source buffer talks to.

Each project now gets its own dedicated REPL. The REPL buffer is named per project (derived from `neocaml-repl-buffer-name`, e.g. `*OCaml: myproject*`, via `project.el` with a `dune-project` fallback), and every send/interrupt/clear/restart command routes to the current buffer's project REPL through a single resolver (`neocaml-repl--buffer`): in a REPL buffer it targets that buffer, otherwise the project's REPL. So you can have several OCaml projects open side by side, each with its own toplevel.

This also fixes `neocaml-dune-utop`: it used a separate buffer name, so the send commands never reached it. It now shares the per-project REPL.

`neocaml-repl-buffer-name` stays the base name; files outside any project use it as-is.

Follow-up: toplevel flavor switching (plain ocaml / utop / dune-utop) builds on this resolver and will come next.

Note: the `snapshot` CI job is expected to fail (the known upstream Emacs-master regression, #67) and is non-blocking.