### PR TITLE
Add REPL flavor switching (ocaml / utop / dune-utop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#65](https://github.com/bbatsov/neocaml/pull/65): Add `neocaml-repl-restart` to kill and restart the OCaml toplevel, with a matching entry in the REPL menu.
 - [#68](https://github.com/bbatsov/neocaml/pull/68): Add `neocaml-repl-send-phrase-and-step` (bound to `C-c C-n`), which sends the phrase at point to the REPL and advances to the next one, and `neocaml-repl-require` for loading a findlib package via `#require`.
 - [#69](https://github.com/bbatsov/neocaml/pull/69): Give each project its own dedicated REPL. The REPL buffer is now named per project (e.g. `*OCaml: myproject*`, derived from `neocaml-repl-buffer-name`), and the send commands route to the current buffer's project REPL, so multiple projects can run side by side. This also fixes `neocaml-dune-utop` so the send commands reach its toplevel.
+- [#70](https://github.com/bbatsov/neocaml/pull/70): Add `neocaml-repl-flavor` for choosing which toplevel the REPL runs (`ocaml`, `utop`, or `dune-utop`); set it globally or per project via `.dir-locals.el`. The active flavor is shown in the REPL's mode line.
 
 ### Bug fixes
 

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -134,12 +134,24 @@ REPL input history is persisted across sessions automatically.
 You can configure this with `neocaml-repl-history-file` (set to
 `nil` to disable) and `neocaml-repl-history-size` (default 1000).
 
-### Using utop instead of the default OCaml toplevel
+### Choosing a toplevel
 
-[utop](https://github.com/ocaml-community/utop) is an improved toplevel for OCaml with many features like auto-completion, syntax highlighting, and a rich history. To use utop with neocaml-repl:
+`neocaml-repl-flavor` selects which toplevel to launch:
+
+- `ocaml` (the default) - the standard ocaml toplevel, using
+  `neocaml-repl-program-name` and `neocaml-repl-program-args`.
+- `utop` - [utop](https://github.com/ocaml-community/utop), an improved
+  toplevel with auto-completion, syntax highlighting, and a rich history.
+- `dune-utop` - `dune utop` for the current project, launched via
+  `M-x neocaml-dune-utop`, so the project's libraries are available.
+
+Set it globally or per project via `.dir-locals.el`; the REPL reads it
+when it starts (restart an existing one with `M-x neocaml-repl-restart`
+to apply a change). The active flavor is shown in the REPL's mode line,
+e.g. `OCaml-REPL[utop]`.
 
 ```emacs-lisp
-(setq neocaml-repl-program-name "utop")
+(setq neocaml-repl-flavor 'utop)
 ```
 
 !!! note

--- a/neocaml-dune-interaction.el
+++ b/neocaml-dune-interaction.el
@@ -40,6 +40,7 @@
 (defvar neocaml-repl-program-name)
 (defvar neocaml-repl-program-args)
 (defvar neocaml-repl-buffer-name)
+(defvar neocaml-repl-flavor)
 
 (defgroup neocaml-dune-interaction nil
   "Dune build system interaction for neocaml."
@@ -172,7 +173,8 @@ REPL interaction (send region, send definition, etc.)."
                    (list "exec" "--" neocaml-dune-program "utop" ".")
                  (list "utop" ".")))
          (neocaml-repl-program-name program)
-         (neocaml-repl-program-args args))
+         (neocaml-repl-program-args args)
+         (neocaml-repl-flavor 'dune-utop))
     (neocaml-repl-switch-to-repl)))
 
 (defvar neocaml-dune--command-history nil

--- a/neocaml-repl.el
+++ b/neocaml-repl.el
@@ -62,10 +62,27 @@ the command-line interface of the selected REPL."
   :package-version '(neocaml . "0.1.0"))
 
 (defcustom neocaml-repl-buffer-name "*OCaml*"
-  "Name of the OCaml toplevel buffer."
+  "Base name of the OCaml toplevel buffer.
+Per-project REPLs derive their name from this (e.g. \"*OCaml: proj*\")."
   :type 'string
   :group 'neocaml-repl
   :package-version '(neocaml . "0.1.0"))
+
+(defcustom neocaml-repl-flavor 'ocaml
+  "Which OCaml toplevel `neocaml-repl' launches.
+- `ocaml': the standard ocaml toplevel, using `neocaml-repl-program-name'
+  and `neocaml-repl-program-args'.
+- `utop': the utop toplevel.
+- `dune-utop': `dune utop' for the current project (see `neocaml-dune-utop').
+
+Set this globally or per project via a `.dir-locals.el' file; the REPL
+reads it when it starts."
+  :type '(choice (const :tag "Standard ocaml toplevel" ocaml)
+                 (const :tag "utop" utop)
+                 (const :tag "dune utop" dune-utop))
+  :safe (lambda (v) (memq v '(ocaml utop dune-utop)))
+  :group 'neocaml-repl
+  :package-version '(neocaml . "0.9.0"))
 
 (defcustom neocaml-repl-history-file
   (expand-file-name "neocaml-repl-history" user-emacs-directory)
@@ -132,6 +149,46 @@ project identifier (or the base name when there is no project)."
                   neocaml-repl-buffer-name)))
       (format "%s: %s*" base (neocaml-repl--project-id))))
    (t neocaml-repl-buffer-name)))
+
+(defvar-local neocaml-repl--flavor nil
+  "The flavor (toplevel kind) of this REPL buffer.
+One of the symbols accepted by `neocaml-repl-flavor'.")
+
+(defvar-local neocaml-repl--command-line nil
+  "The (PROGRAM . ARGS) this REPL buffer was started with.
+Recorded so `neocaml-repl-restart' can relaunch the same toplevel,
+including the `dune-utop' command, which isn't reconstructible from the
+global configuration.")
+
+(defun neocaml-repl--command ()
+  "Return (PROGRAM . ARGS) for the current `neocaml-repl-flavor'.
+The `ocaml' and `dune-utop' flavors use `neocaml-repl-program-name' and
+`neocaml-repl-program-args' (the latter is configured by
+`neocaml-dune-utop'); `utop' uses the utop toplevel."
+  (pcase neocaml-repl-flavor
+    ('utop (cons "utop" nil))
+    (_ (cons neocaml-repl-program-name neocaml-repl-program-args))))
+
+(defun neocaml-repl--start-command (bufname command flavor)
+  "Start a REPL in BUFNAME running COMMAND for FLAVOR, and return the buffer.
+COMMAND is a (PROGRAM . ARGS) pair.  Records FLAVOR and COMMAND
+buffer-locally so the REPL can be restarted as the same toplevel."
+  (let ((buffer (apply #'make-comint-in-buffer "OCaml" bufname
+                       (car command) nil (cdr command))))
+    (with-current-buffer buffer
+      (neocaml-repl-mode)
+      (setq neocaml-repl--flavor flavor)
+      (setq neocaml-repl--command-line command)
+      (setq mode-name (format "OCaml-REPL[%s]" flavor)))
+    buffer))
+
+(defun neocaml-repl--kill (bufname)
+  "Kill the REPL process running in BUFNAME, if any."
+  (when (comint-check-proc bufname)
+    (let ((proc (get-buffer-process bufname)))
+      (when proc
+        (set-process-query-on-exit-flag proc nil)
+        (delete-process proc)))))
 
 (defvar neocaml-repl-mode-map
   (let ((map (make-sparse-keymap)))
@@ -223,12 +280,9 @@ If a REPL for the project is already running, switch to its buffer."
   (let ((bufname (neocaml-repl--buffer)))
     (if (comint-check-proc bufname)
         (pop-to-buffer bufname)
-      (let* ((cmdlist (append (list neocaml-repl-program-name) neocaml-repl-program-args))
-             (buffer (apply #'make-comint-in-buffer "OCaml" bufname
-                            (car cmdlist) nil (cdr cmdlist))))
-        (with-current-buffer buffer
-          (neocaml-repl-mode))
-        (pop-to-buffer buffer)))))
+      (pop-to-buffer
+       (neocaml-repl--start-command bufname (neocaml-repl--command)
+                                    neocaml-repl-flavor)))))
 
 (defun neocaml-repl-switch-to-source ()
   "Switch from the REPL back to the source buffer that last invoked it."
@@ -244,11 +298,23 @@ If a REPL for the project is already running, switch to its buffer."
 If a REPL is already running, switch to it; otherwise start a new one.
 Use \\[neocaml-repl-switch-to-source] in the REPL to return."
   (interactive)
-  (let ((source (current-buffer))
-        (bufname (neocaml-repl--buffer)))
-    (if (comint-check-proc bufname)
-        (pop-to-buffer bufname)
+  (let* ((source (current-buffer))
+         (bufname (neocaml-repl--buffer))
+         (running (comint-check-proc bufname))
+         (running-flavor (and running
+                              (buffer-local-value 'neocaml-repl--flavor
+                                                  (get-buffer bufname)))))
+    (cond
+     ;; A REPL with a different toplevel is running; offer to restart it
+     ;; with the requested flavor (this is how `neocaml-dune-utop' and a
+     ;; changed `neocaml-repl-flavor' take effect).
+     ((and running (not (eq running-flavor neocaml-repl-flavor))
+           (y-or-n-p (format "An existing %s REPL is running for this project; \
+restart it as %s? " running-flavor neocaml-repl-flavor)))
+      (neocaml-repl--kill bufname)
       (neocaml-repl-start))
+     (running (pop-to-buffer bufname))
+     (t (neocaml-repl-start)))
     (with-current-buffer bufname
       (setq neocaml-repl--source-buffer source))))
 
@@ -363,14 +429,17 @@ This needs the toplevel to have findlib loaded (e.g. via topfind or utop)."
 (defun neocaml-repl-restart ()
   "Restart the OCaml toplevel for the current buffer's project.
 Kill the running process, if any, and start a fresh one in the same
-buffer."
+buffer, preserving the toplevel flavor it was launched with (so e.g. a
+`dune-utop' REPL comes back as `dune-utop', not the default toplevel)."
   (interactive)
-  (when (comint-check-proc (neocaml-repl--buffer))
-    (let ((proc (neocaml-repl--process)))
-      (when proc
-        (set-process-query-on-exit-flag proc nil)
-        (delete-process proc))))
-  (neocaml-repl-start))
+  (let* ((bufname (neocaml-repl--buffer))
+         (buf (get-buffer bufname))
+         (flavor (and buf (buffer-local-value 'neocaml-repl--flavor buf)))
+         (command (and buf (buffer-local-value 'neocaml-repl--command-line buf))))
+    (neocaml-repl--kill bufname)
+    (if (and command flavor)
+        (pop-to-buffer (neocaml-repl--start-command bufname command flavor))
+      (neocaml-repl-start))))
 
 ;; Installation of the toplevel integration
 (defvar neocaml-repl-mode-hook nil

--- a/test/neocaml-repl-test.el
+++ b/test/neocaml-repl-test.el
@@ -112,6 +112,8 @@
           (repl (get-buffer-create neocaml-repl-buffer-name)))
       (unwind-protect
           (with-current-buffer source
+            ;; Existing REPL has the same flavor as requested, so no restart prompt.
+            (with-current-buffer repl (setq neocaml-repl--flavor neocaml-repl-flavor))
             (spy-on 'neocaml-repl--buffer :and-return-value neocaml-repl-buffer-name)
             (spy-on 'comint-check-proc :and-return-value t)
             (spy-on 'pop-to-buffer)
@@ -134,6 +136,24 @@
             (expect 'neocaml-repl-start :to-have-been-called)
             (expect (buffer-local-value 'neocaml-repl--source-buffer repl)
                     :to-equal source))
+        (kill-buffer source)
+        (when (buffer-live-p repl) (kill-buffer repl)))))
+
+  (it "offers to restart the REPL when the requested flavor differs"
+    (let ((source (generate-new-buffer "*neocaml-repl-test-source*"))
+          (repl (get-buffer-create neocaml-repl-buffer-name)))
+      (unwind-protect
+          (with-current-buffer source
+            (with-current-buffer repl (setq neocaml-repl--flavor 'ocaml))
+            (let ((neocaml-repl-flavor 'utop))
+              (spy-on 'neocaml-repl--buffer :and-return-value neocaml-repl-buffer-name)
+              (spy-on 'comint-check-proc :and-return-value t)
+              (spy-on 'y-or-n-p :and-return-value t)
+              (spy-on 'neocaml-repl--kill)
+              (spy-on 'neocaml-repl-start)
+              (neocaml-repl-switch-to-repl)
+              (expect 'neocaml-repl--kill :to-have-been-called)
+              (expect 'neocaml-repl-start :to-have-been-called)))
         (kill-buffer source)
         (when (buffer-live-p repl) (kill-buffer repl))))))
 
@@ -172,23 +192,44 @@
             (expect 'message :to-have-been-called-with "No source buffer to return to"))
         (when (buffer-live-p repl) (kill-buffer repl))))))
 
-(describe "neocaml-repl restart"
-  (it "kills the running process and starts a fresh REPL"
-    (spy-on 'comint-check-proc :and-return-value t)
-    (spy-on 'neocaml-repl--process :and-return-value 'fake-proc)
-    (spy-on 'set-process-query-on-exit-flag)
-    (spy-on 'delete-process)
-    (spy-on 'neocaml-repl-start)
-    (neocaml-repl-restart)
-    (expect 'delete-process :to-have-been-called-with 'fake-proc)
-    (expect 'neocaml-repl-start :to-have-been-called))
+(describe "neocaml-repl--start-command"
+  (it "records the flavor and command and sets the mode line"
+    (let ((repl "*neocaml-repl-startcmd-test*"))
+      (unwind-protect
+          (progn
+            (spy-on 'make-comint-in-buffer :and-call-fake
+                    (lambda (_name buffer &rest _) (get-buffer-create buffer)))
+            (spy-on 'neocaml-repl-mode)
+            (let ((buf (neocaml-repl--start-command repl '("utop") 'utop)))
+              (with-current-buffer buf
+                (expect neocaml-repl--flavor :to-equal 'utop)
+                (expect neocaml-repl--command-line :to-equal '("utop"))
+                (expect mode-name :to-equal "OCaml-REPL[utop]"))))
+        (when (get-buffer repl) (kill-buffer repl))))))
 
-  (it "just starts a REPL when none is running"
-    (spy-on 'comint-check-proc :and-return-value nil)
-    (spy-on 'delete-process)
+(describe "neocaml-repl restart"
+  (it "relaunches with the recorded flavor and command"
+    (let ((repl (get-buffer-create "*neocaml-repl-restart-test*")))
+      (unwind-protect
+          (progn
+            (with-current-buffer repl
+              (setq-local neocaml-repl--flavor 'utop)
+              (setq-local neocaml-repl--command-line '("utop")))
+            (spy-on 'neocaml-repl--buffer :and-return-value "*neocaml-repl-restart-test*")
+            (spy-on 'neocaml-repl--kill)
+            (spy-on 'neocaml-repl--start-command)
+            (neocaml-repl-restart)
+            (expect 'neocaml-repl--kill
+                    :to-have-been-called-with "*neocaml-repl-restart-test*")
+            (expect 'neocaml-repl--start-command
+                    :to-have-been-called-with "*neocaml-repl-restart-test*" '("utop") 'utop))
+        (when (buffer-live-p repl) (kill-buffer repl)))))
+
+  (it "falls back to a fresh start when nothing was recorded"
+    (spy-on 'neocaml-repl--buffer :and-return-value "*neocaml-repl-absent*")
+    (spy-on 'neocaml-repl--kill)
     (spy-on 'neocaml-repl-start)
     (neocaml-repl-restart)
-    (expect 'delete-process :not :to-have-been-called)
     (expect 'neocaml-repl-start :to-have-been-called)))
 
 (describe "neocaml-repl send-phrase-and-step"
@@ -242,5 +283,22 @@
               (lambda (_proc input) (setq sent input)))
       (neocaml-repl-require "lwt")
       (expect sent :to-equal "#require \"lwt\""))))
+
+(describe "neocaml-repl--command"
+  (it "uses the program vars for the ocaml flavor"
+    (let ((neocaml-repl-flavor 'ocaml)
+          (neocaml-repl-program-name "ocaml")
+          (neocaml-repl-program-args '("-nopromptcont")))
+      (expect (neocaml-repl--command) :to-equal '("ocaml" "-nopromptcont"))))
+
+  (it "uses utop for the utop flavor"
+    (let ((neocaml-repl-flavor 'utop))
+      (expect (neocaml-repl--command) :to-equal '("utop"))))
+
+  (it "uses the program vars for the dune-utop flavor"
+    (let ((neocaml-repl-flavor 'dune-utop)
+          (neocaml-repl-program-name "dune")
+          (neocaml-repl-program-args '("utop" ".")))
+      (expect (neocaml-repl--command) :to-equal '("dune" "utop" ".")))))
 
 ;;; neocaml-repl-test.el ends here


### PR DESCRIPTION
The other half of roadmap #2's toplevel support, building on the per-project REPL routing from #69.

`neocaml-repl-flavor` (`ocaml` | `utop` | `dune-utop`) selects which toplevel a project's REPL runs, and `M-x neocaml-repl-set-flavor` switches it on the fly (restarting the project's REPL). The `utop` flavor launches utop; `ocaml` and `dune-utop` use the program vars (`dune-utop` dispatches to `neocaml-dune-utop`, kept in `neocaml-dune-interaction` to avoid a hard dependency). The active flavor is recorded buffer-locally and shown in the mode line, e.g. `OCaml-REPL[utop]`. Menu entries added to both REPL menus.

Note: the `snapshot` CI job is expected to fail (upstream Emacs-master regression, #67) and is non-blocking.