### PR TITLE
Integrate with project.el for dune projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#68](https://github.com/bbatsov/neocaml/pull/68): Add `neocaml-repl-send-phrase-and-step` (bound to `C-c C-n`), which sends the phrase at point to the REPL and advances to the next one, and `neocaml-repl-require` for loading a findlib package via `#require`.
 - [#69](https://github.com/bbatsov/neocaml/pull/69): Give each project its own dedicated REPL. The REPL buffer is now named per project (e.g. `*OCaml: myproject*`, derived from `neocaml-repl-buffer-name`), and the send commands route to the current buffer's project REPL, so multiple projects can run side by side. This also fixes `neocaml-dune-utop` so the send commands reach its toplevel.
 - [#70](https://github.com/bbatsov/neocaml/pull/70): Add `neocaml-repl-flavor` for choosing which toplevel the REPL runs (`ocaml`, `utop`, or `dune-utop`); set it globally or per project via `.dir-locals.el`. The active flavor is shown in the REPL's mode line.
+- [#71](https://github.com/bbatsov/neocaml/pull/71): Integrate with `project.el`: a directory containing a `dune-project` file is recognized as a project root (for non-VC projects), `_build/` and `_opam/` are ignored, and `compile-command` defaults to `dune build` in dune projects.
 
 ### Bug fixes
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -118,6 +118,21 @@ errors, warnings, alerts, and exception backtraces.
 For a richer build workflow with dune (build, test, clean, fmt, watch mode),
 see [dune commands](opam_and_dune.md#dune-commands).
 
+In a dune project, `compile-command` defaults to `dune build`, so `C-c C-c`
+and `M-x project-compile` build the project out of the box.
+
+## Project Integration
+
+neocaml teaches the built-in `project.el` that a directory containing a
+`dune-project` file is a project root. That makes the project-wide commands
+work for OCaml projects - `project-find-file` (`C-x p f`),
+`project-find-regexp` (`C-x p g`), `project-compile` (`C-x p c`), and the
+rest - rooted at the dune project, with `_build/` and `_opam/` ignored.
+
+Version-control detection still takes precedence, so a project under git
+roots at the repository as usual; the dune-project detection mainly helps
+projects that aren't under version control.
+
 ## Other OCaml-related Files
 
 neocaml also registers sensible modes for a few other OCaml-related files:

--- a/neocaml.el
+++ b/neocaml.el
@@ -40,6 +40,7 @@
 
 (require 'treesit)
 (require 'seq)
+(require 'project)
 
 (defgroup neocaml nil
   "Major mode for editing OCaml code with tree-sitter."
@@ -726,6 +727,30 @@ formats whole compilation units, so there is no region/defun variant."
   "Format the buffer before saving when `neocaml-format-on-save' is non-nil."
   (when neocaml-format-on-save
     (neocaml-format-buffer)))
+
+;;;; Project integration
+;;
+;; Teach `project.el' that a directory containing a `dune-project' file is a
+;; project root, so project-wide commands (find-file, search, compile, ...)
+;; work for OCaml/dune projects.  Registered with APPEND so version-control
+;; detection still takes precedence when a project is under git/hg/etc.; this
+;; mainly fills the gap for dune projects that aren't under version control.
+
+(defun neocaml-project-find (dir)
+  "Return the dune project containing DIR, or nil.
+The project root is the closest directory at or above DIR that contains
+a `dune-project' file."
+  (when-let* ((root (locate-dominating-file dir "dune-project")))
+    (list 'neocaml (expand-file-name root))))
+
+(cl-defmethod project-root ((project (head neocaml)))
+  (cadr project))
+
+(cl-defmethod project-ignores ((_project (head neocaml)) _dir)
+  "Ignore OCaml build/switch artifacts in addition to the defaults."
+  (append '("_build/" "_opam/") (cl-call-next-method)))
+
+(add-hook 'project-find-functions #'neocaml-project-find t)
 
 ;;;; Find the definition at point (some Emacs commands use this internally)
 
@@ -1590,6 +1615,10 @@ for .ml files and `neocaml-interface-mode' for .mli files."
 
   ;; Optional format-on-save via ocamlformat
   (add-hook 'before-save-hook #'neocaml--format-before-save nil t)
+
+  ;; Default to `dune build' for `compile'/`project-compile' in dune projects.
+  (when (locate-dominating-file default-directory "dune-project")
+    (setq-local compile-command "dune build"))
 
   ;; Make URLs and bug references in comments clickable.  Set
   ;; `bug-reference-url-format' (e.g. via .dir-locals.el) to resolve refs.

--- a/test/neocaml-project-test.el
+++ b/test/neocaml-project-test.el
@@ -1,0 +1,75 @@
+;;; neocaml-project-test.el --- project.el backend tests -*- lexical-binding: t; -*-
+
+;; Copyright © 2025-2026 Bozhidar Batsov
+
+;;; Commentary:
+
+;; Buttercup tests for neocaml's project.el integration: detecting a
+;; dune-project root, ignoring build artifacts, and the dune compile-command.
+
+;;; Code:
+
+(require 'neocaml-test-helpers)
+(require 'project)
+
+(defmacro neocaml-test--with-dune-project (var &rest body)
+  "Create a temp dune project directory, bind its path to VAR, run BODY.
+A `dune-project' file and a `lib/' subdirectory are created."
+  (declare (indent 1))
+  `(let ((,var (file-name-as-directory (make-temp-file "neocaml-proj" t))))
+     (unwind-protect
+         (progn
+           (write-region "" nil (expand-file-name "dune-project" ,var))
+           (make-directory (expand-file-name "lib" ,var) t)
+           ,@body)
+       (delete-directory ,var t))))
+
+(describe "neocaml project.el integration"
+  (describe "neocaml-project-find"
+    (it "finds the dune-project root from the project directory"
+      (neocaml-test--with-dune-project root
+        (expect (neocaml-project-find root)
+                :to-equal (list 'neocaml root))))
+
+    (it "finds the root from a subdirectory"
+      (neocaml-test--with-dune-project root
+        (expect (project-root (neocaml-project-find (expand-file-name "lib" root)))
+                :to-equal root)))
+
+    (it "returns nil when there is no dune-project"
+      (let ((dir (file-name-as-directory (make-temp-file "neocaml-noproj" t))))
+        (unwind-protect
+            (expect (neocaml-project-find dir) :to-be nil)
+          (delete-directory dir t)))))
+
+  (describe "project-ignores"
+    (it "ignores OCaml build and switch artifacts"
+      (neocaml-test--with-dune-project root
+        (let ((ignores (project-ignores (neocaml-project-find root) root)))
+          (expect (member "_build/" ignores) :to-be-truthy)
+          (expect (member "_opam/" ignores) :to-be-truthy)))))
+
+  (describe "compile-command"
+    (it "defaults to `dune build' inside a dune project"
+      (unless (treesit-language-available-p 'ocaml)
+        (signal 'buttercup-pending "tree-sitter OCaml grammar not available"))
+      (neocaml-test--with-dune-project root
+        (with-temp-buffer
+          (setq default-directory root)
+          (neocaml-mode)
+          (expect compile-command :to-equal "dune build"))))
+
+    (it "is left at its default outside a dune project"
+      (unless (treesit-language-available-p 'ocaml)
+        (signal 'buttercup-pending "tree-sitter OCaml grammar not available"))
+      (let ((dir (file-name-as-directory (make-temp-file "neocaml-noproj" t))))
+        (unwind-protect
+            (with-temp-buffer
+              (setq default-directory dir)
+              (neocaml-mode)
+              (expect compile-command :not :to-equal "dune build"))
+          (delete-directory dir t))))))
+
+(provide 'neocaml-project-test)
+
+;;; neocaml-project-test.el ends here


### PR DESCRIPTION
Roadmap #8. Teaches the built-in `project.el` that a directory containing a `dune-project` file is a project root, so the project-wide commands (`project-find-file`, `project-find-regexp`, `project-compile`, ...) work for OCaml projects.

- `neocaml-project-find` is added to `project-find-functions` with APPEND, so version-control detection still wins; the dune-project backend mainly fills the gap for projects that aren't under version control (and reuses the same root logic as the per-project REPL).
- `project-root`/`project-ignores` methods, ignoring `_build/` and `_opam/`.
- `compile-command` defaults to `dune build` in dune projects, so `C-c C-c` / `project-compile` build out of the box.

Note: the `snapshot` CI job is expected to fail (upstream Emacs-master regression, #67) and is non-blocking.