### PR TITLE
Add neocaml-utop: a utop backend over its native -emacs protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-- Add `neocaml-utop`, an alternative toplevel backend that drives utop through its native editor protocol (`utop -emacs`). It runs in a comint-based transcript with input history and completion-at-point backed by utop's own engine, separates output/results/errors/warnings, and underlines the exact sub-expression a parse or type error points at in the source buffer. Sending a phrase or definition from a source buffer also echoes its result in the minibuffer (SLIME/CIDER style; toggle with `neocaml-utop-echo-eval-result`). Enable `neocaml-utop-minor-mode` in OCaml buffers to use it; the keybindings mirror `neocaml-repl-minor-mode`.
+- Add `neocaml-utop`, an alternative toplevel backend that drives utop through its native editor protocol (`utop -emacs`). It runs in a comint-based transcript with input history and completion-at-point backed by utop's own engine, separates output/results/errors/warnings, and underlines the exact sub-expression a parse or type error points at in the source buffer (with the error message as the overlay's tooltip; the underline clears when you edit the code). Source evaluations cover every `;;`-separated phrase in the region, and the result is shown both in the minibuffer (SLIME/CIDER style; toggle with `neocaml-utop-echo-eval-result`) and inline in the source buffer as a `=> ...` overlay (toggle with `neocaml-utop-inline-eval-result`). In the transcript, `RET` submits a complete phrase and otherwise inserts a newline, so multi-line phrases can be entered naturally. Enable `neocaml-utop-minor-mode` in OCaml buffers to use it; the keybindings mirror `neocaml-repl-minor-mode`.
 
 ## 0.9.0 (2026-06-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### New features
+
+- Add `neocaml-utop`, an alternative toplevel backend that drives utop through its native editor protocol (`utop -emacs`). It runs in a comint-based transcript with input history and completion-at-point backed by utop's own engine, separates output/results/errors/warnings, and underlines the exact sub-expression a parse or type error points at in the source buffer. Enable `neocaml-utop-minor-mode` in OCaml buffers to use it; the keybindings mirror `neocaml-repl-minor-mode`.
+
 ## 0.9.0 (2026-06-24)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-- Add `neocaml-utop`, an alternative toplevel backend that drives utop through its native editor protocol (`utop -emacs`). It runs in a comint-based transcript with input history and completion-at-point backed by utop's own engine, separates output/results/errors/warnings, and underlines the exact sub-expression a parse or type error points at in the source buffer. Enable `neocaml-utop-minor-mode` in OCaml buffers to use it; the keybindings mirror `neocaml-repl-minor-mode`.
+- Add `neocaml-utop`, an alternative toplevel backend that drives utop through its native editor protocol (`utop -emacs`). It runs in a comint-based transcript with input history and completion-at-point backed by utop's own engine, separates output/results/errors/warnings, and underlines the exact sub-expression a parse or type error points at in the source buffer. Sending a phrase or definition from a source buffer also echoes its result in the minibuffer (SLIME/CIDER style; toggle with `neocaml-utop-echo-eval-result`). Enable `neocaml-utop-minor-mode` in OCaml buffers to use it; the keybindings mirror `neocaml-repl-minor-mode`.
 
 ## 0.9.0 (2026-06-24)
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It's also as cool as Neo from "The Matrix". ;-)
 - Navigation (`beginning-of-defun`, `end-of-defun`, `forward-sexp`, sentence movement with `M-a`/`M-e`)
 - Imenu with language-specific categories for `.ml` and `.mli`
 - Toggling between implementation and interface via `ff-find-other-file` (`C-c C-a`)
-- OCaml toplevel (REPL) integration (`neocaml-repl`)
+- OCaml toplevel (REPL) integration (`neocaml-repl`), plus an alternative utop backend (`neocaml-utop`) that speaks utop's native protocol for precise error highlighting and completion
 - Comment support: `fill-paragraph` (`M-q`), comment continuation (`M-j`), and `comment-dwim` (`M-;`)
 - Electric indentation on delimiter characters
 - opam file editing (`neocaml-opam-mode`) with font-lock, indentation, imenu, and `opam lint` integration (flymake and [flycheck](https://github.com/flycheck/flycheck))

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -216,13 +216,25 @@ Choose between plain utop and `dune utop` with `neocaml-utop-flavor`
 `dune-utop` makes the project's own libraries available in the toplevel.
 `M-x neocaml-utop-require` loads a findlib package via `#require`.
 
-Sending a phrase or definition from a source buffer also echoes its
-result (or error) in the minibuffer, SLIME/CIDER style, while the full
-output still goes to the transcript. Disable this with:
+Sending a phrase or definition from a source buffer also shows its
+result (or error) two ways, SLIME/CIDER style, while the full output
+still goes to the transcript: echoed in the minibuffer, and inline in
+the source buffer as a `=> ...` overlay at the end of the evaluated form
+(the overlay clears on the next evaluation or when you edit the code).
+Toggle either independently:
 
 ```emacs-lisp
-(setq neocaml-utop-echo-eval-result nil)
+(setq neocaml-utop-echo-eval-result nil)    ; no minibuffer echo
+(setq neocaml-utop-inline-eval-result nil)  ; no inline => overlay
 ```
+
+Region and buffer sends evaluate every `;;`-separated phrase in the
+selection, not just the first. In the transcript itself, `RET` submits
+the input when it forms a complete phrase (ends with `;;`, or is a `#`
+directive) and otherwise inserts a newline, so you can type multi-line
+phrases naturally; `RET` on a blank line submits regardless. When an
+evaluation fails, the underlined span in the source carries the error
+message as its tooltip.
 
 !!! note
     `neocaml-utop` needs utop (it relies on the `-emacs` protocol), so it

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -216,6 +216,14 @@ Choose between plain utop and `dune utop` with `neocaml-utop-flavor`
 `dune-utop` makes the project's own libraries available in the toplevel.
 `M-x neocaml-utop-require` loads a findlib package via `#require`.
 
+Sending a phrase or definition from a source buffer also echoes its
+result (or error) in the minibuffer, SLIME/CIDER style, while the full
+output still goes to the transcript. Disable this with:
+
+```emacs-lisp
+(setq neocaml-utop-echo-eval-result nil)
+```
+
 !!! note
     `neocaml-utop` needs utop (it relies on the `-emacs` protocol), so it
     doesn't apply to the standard `ocaml` toplevel. Pick one backend per

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -155,13 +155,69 @@ e.g. `OCaml-REPL[utop]`.
 ```
 
 !!! note
-    Don't pass utop's `-emacs` flag; it activates a structured
-    protocol meant for the old `utop.el` integration, which
-    `neocaml-repl' doesn't implement.  Plain `utop` works fine with
-    the comint-based REPL.
+    Don't pass utop's `-emacs` flag here. It activates a structured
+    protocol that the comint-based REPL doesn't speak; plain `utop`
+    works fine with `neocaml-repl`. If you want that protocol, use the
+    dedicated [`neocaml-utop`](#the-utop-protocol-backend) backend
+    described below.
 
 !!! note
     If Emacs can't find `utop` or `ocaml`, your shell `PATH` may not be
     inherited. See
     [Troubleshooting](troubleshooting.md#ocamllsp-not-found-macos-gui-emacs)
     for the fix.
+
+## The utop protocol backend
+
+`neocaml-utop` is an alternative toplevel integration that drives utop
+through its native editor protocol (`utop -emacs`) instead of treating
+it as a plain comint stream. It's a separate module from `neocaml-repl`;
+use whichever you prefer. `neocaml-repl` remains the right choice for the
+standard `ocaml` toplevel, which has no protocol of its own.
+
+In protocol mode utop does no rendering itself and reports structured
+information that a raw stream can't, which lets `neocaml-utop`:
+
+- separate output, results, errors, and warnings without guessing from
+  the text;
+- underline the **exact** sub-expression a parse or type error points at,
+  back in your source buffer (see the `neocaml-utop-error-face` face),
+  rather than just the line;
+- answer completion from utop's own engine, wired into
+  `completion-at-point` in the transcript.
+
+The transcript is a comint derivative, so input editing, history (with
+optional persistence via `neocaml-utop-history-file`), and read-only
+prompts work as usual.
+
+Enable the source-buffer minor mode to get the keybindings, then press
+`C-c C-z` to start a session:
+
+```emacs-lisp
+(add-hook 'neocaml-base-mode-hook #'neocaml-utop-minor-mode)
+```
+
+The keybindings mirror `neocaml-repl-minor-mode`:
+
+| Keybinding | Command | Description |
+|------------|---------|-------------|
+| `C-c C-z` | `neocaml-utop-switch-to-utop` | Start utop or switch to a running session |
+| `C-c C-c` | `neocaml-utop-send-definition` | Send the definition at point |
+| `C-c C-r` | `neocaml-utop-send-region` | Send the active region |
+| `C-c C-b` | `neocaml-utop-send-buffer` | Send the whole buffer |
+| `C-c C-p` | `neocaml-utop-send-phrase` | Send the phrase at point (code up to `;;`) |
+| `C-c C-n` | `neocaml-utop-send-phrase-and-step` | Send the phrase, then move to the next one |
+| `C-c C-l` | `neocaml-utop-load-file` | Load the current file via `#use` |
+| `C-c C-i` | `neocaml-utop-interrupt` | Interrupt the utop process |
+| `C-c C-k` | `neocaml-utop-clear-buffer` | Clear the transcript buffer |
+
+Choose between plain utop and `dune utop` with `neocaml-utop-flavor`
+(`utop` or `dune-utop`), set globally or per project via `.dir-locals.el`;
+`dune-utop` makes the project's own libraries available in the toplevel.
+`M-x neocaml-utop-require` loads a findlib package via `#require`.
+
+!!! note
+    `neocaml-utop` needs utop (it relies on the `-emacs` protocol), so it
+    doesn't apply to the standard `ocaml` toplevel. Pick one backend per
+    buffer: enable either `neocaml-repl-minor-mode` or
+    `neocaml-utop-minor-mode`, since they share the same keybindings.

--- a/neocaml-utop.el
+++ b/neocaml-utop.el
@@ -1,0 +1,619 @@
+;;; neocaml-utop.el --- utop toplevel integration via its Emacs protocol -*- lexical-binding: t; -*-
+
+;; Copyright © 2025-2026 Bozhidar Batsov
+;;
+;; Author: Bozhidar Batsov <bozhidar@batsov.dev>
+;; Maintainer: Bozhidar Batsov <bozhidar@batsov.dev>
+;; URL: http://github.com/bbatsov/neocaml
+;; Keywords: languages ocaml
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; An alternative OCaml toplevel integration that drives `utop' through
+;; its native editor protocol (`utop -emacs') instead of treating it as a
+;; plain comint stream like `neocaml-repl' does.
+;;
+;; In `-emacs' mode utop does no rendering of its own: it speaks a small
+;; line-based protocol of `command:argument' messages over stdin/stdout.
+;; This lets neocaml present a proper transcript while getting things a
+;; raw stream cannot provide:
+;;
+;; - stdout, stderr, results, errors and warnings arrive already
+;;   separated, so no regexp sniffing is needed to tell them apart;
+;; - parse and type errors come with character ranges into the submitted
+;;   phrase, which we map back onto the *source* buffer and underline
+;;   precisely (see `neocaml-utop-error-face');
+;; - completion is answered by utop's own engine, wired here into
+;;   `completion-at-point'.
+;;
+;; The transcript buffer is a `comint' derivative, so input editing,
+;; history (with optional persistence) and read-only prompts come for
+;; free; only the transport is custom (a preoutput filter that parses the
+;; protocol and an input sender that emits it).
+;;
+;; This module is independent of `neocaml-repl': use whichever you
+;; prefer.  `neocaml-repl' remains the right choice for the plain `ocaml'
+;; toplevel, which has no protocol of its own.
+
+;;; License:
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Code:
+
+(require 'comint)
+(require 'pulse)
+(require 'subr-x)
+(require 'neocaml)
+(require 'neocaml-common)
+;; Reused for the transport-agnostic source-side helpers (project naming
+;; and `;;'-delimited phrase bounds); `neocaml-repl' itself is untouched.
+(require 'neocaml-repl)
+
+(defgroup neocaml-utop nil
+  "OCaml toplevel integration via utop's Emacs protocol."
+  :prefix "neocaml-utop-"
+  :group 'neocaml)
+
+(defcustom neocaml-utop-program "utop"
+  "Program name used to invoke utop in protocol mode.
+The `-emacs' flag is always appended by neocaml."
+  :type 'string
+  :package-version '(neocaml . "0.10.0"))
+
+(defcustom neocaml-utop-program-args nil
+  "Extra command-line arguments passed to utop before `-emacs'.
+For the `dune-utop' flavor these are passed to the utop that `dune utop'
+launches (i.e. after the `--' separator)."
+  :type '(repeat string)
+  :package-version '(neocaml . "0.10.0"))
+
+(defcustom neocaml-utop-flavor 'utop
+  "Which utop toplevel `neocaml-utop' launches.
+- `utop': run `neocaml-utop-program' directly.
+- `dune-utop': run `dune utop' for the current project, so the project's
+  libraries are available in the toplevel.
+
+Set this globally or per project via a `.dir-locals.el' file."
+  :type '(choice (const :tag "utop" utop)
+                 (const :tag "dune utop" dune-utop))
+  :safe (lambda (v) (memq v '(utop dune-utop)))
+  :package-version '(neocaml . "0.10.0"))
+
+(defcustom neocaml-utop-buffer-name "*utop*"
+  "Base name of the utop transcript buffer.
+Per-project sessions derive their name from this (e.g. \"*utop: proj*\")."
+  :type 'string
+  :package-version '(neocaml . "0.10.0"))
+
+(defcustom neocaml-utop-history-file
+  (expand-file-name "neocaml-utop-history" user-emacs-directory)
+  "File to persist utop input history across sessions.
+Set to nil to disable history persistence."
+  :type '(choice (file :tag "History file")
+                 (const :tag "Disable" nil))
+  :package-version '(neocaml . "0.10.0"))
+
+(defcustom neocaml-utop-history-size 1000
+  "Maximum number of input history entries to persist."
+  :type 'integer
+  :package-version '(neocaml . "0.10.0"))
+
+(defcustom neocaml-utop-completion-at-point t
+  "When non-nil, offer utop-backed completion in the transcript buffer.
+Completion candidates come from utop's own completion engine via the
+protocol's `complete-company' request."
+  :type 'boolean
+  :package-version '(neocaml . "0.10.0"))
+
+(defface neocaml-utop-error-face
+  '((((supports :underline (:style wave)))
+     :underline (:style wave :color "Red1"))
+    (t :inherit error))
+  "Face used to underline utop error spans in the source buffer."
+  :group 'neocaml-utop)
+
+(defconst neocaml-utop--prompt-regexp "^utop\\[[0-9]+\\]> "
+  "Regexp matching the prompt neocaml-utop renders for utop.")
+
+(defvar neocaml-utop-font-lock-keywords
+  '(("\\(val\\) \\([^:]*\\)\\( *:\\)"
+     (1 font-lock-keyword-face) (2 font-lock-variable-name-face))
+    ("\\(type\\) \\([^ =]*\\)"
+     (1 font-lock-keyword-face) (2 font-lock-type-face)))
+  "Font-lock keywords for utop result lines in the transcript buffer.")
+
+;;;; Buffer-local state
+;;
+;; All of these live in the transcript buffer; the preoutput filter runs
+;; there, so it reads and writes them directly.
+
+(defvar-local neocaml-utop--partial ""
+  "Incomplete trailing protocol line buffered between filter calls.")
+
+(defvar-local neocaml-utop--count -1
+  "Number of prompts shown so far, used to number the prompt.")
+
+(defvar-local neocaml-utop--error-target nil
+  "Where to map error offsets for the phrase currently being evaluated.
+A list (BUFFER START END): error character offsets reported by utop are
+relative to buffer position START in BUFFER, and overlays are clamped to
+END (the end of the submitted phrase) so the `;;' we append can't push a
+span past the source.  Nil when the last input was not source-derived
+\(e.g. `#require'/`#use'), so no overlay is drawn.")
+
+(defvar-local neocaml-utop--overlays nil
+  "Error overlays currently shown for the last evaluated phrase.")
+
+(defvar-local neocaml-utop--completions nil
+  "Completion candidates accumulated from the current `complete' request.")
+
+(defvar-local neocaml-utop--completion-state nil
+  "State of an in-flight completion request: `collecting', `done', or nil.")
+
+(defvar-local neocaml-utop--source-buffer nil
+  "Source buffer that last switched to this transcript.")
+
+(defvar-local neocaml-utop--command-line nil
+  "The (PROGRAM ARG...) this transcript was launched with.
+Recorded so `neocaml-utop-restart' relaunches the same toplevel even
+though it runs from the transcript buffer, which lacks the source's
+directory-local `neocaml-utop-flavor'.")
+
+;;;; Session naming and command
+
+(defun neocaml-utop--buffer-name ()
+  "Return the transcript buffer name for the current context.
+In a transcript buffer that is the buffer itself; in a source buffer it
+is the per-project session derived from `neocaml-utop-buffer-name'."
+  (cond
+   ((derived-mode-p 'neocaml-utop-mode) (buffer-name))
+   ((neocaml-repl--project-id)
+    (let ((base (if (string-suffix-p "*" neocaml-utop-buffer-name)
+                    (substring neocaml-utop-buffer-name 0 -1)
+                  neocaml-utop-buffer-name)))
+      (format "%s: %s*" base (neocaml-repl--project-id))))
+   (t neocaml-utop-buffer-name)))
+
+(defun neocaml-utop--command ()
+  "Return (PROGRAM ARG...) for launching utop per `neocaml-utop-flavor'."
+  (pcase neocaml-utop-flavor
+    ('dune-utop
+     (let ((root (or (neocaml-common-dune-project-root) default-directory)))
+       (append (list "dune" "utop" root "--")
+               neocaml-utop-program-args (list "-emacs"))))
+    (_ (append (list neocaml-utop-program)
+               neocaml-utop-program-args (list "-emacs")))))
+
+;;;; Error overlays
+
+(defun neocaml-utop--clear-overlays ()
+  "Remove the error overlays tracked in this transcript buffer."
+  (mapc #'delete-overlay neocaml-utop--overlays)
+  (setq neocaml-utop--overlays nil))
+
+(defun neocaml-utop--handle-accept (arg)
+  "Handle an `accept:ARG' message: ARG is empty on success.
+Otherwise ARG is a comma-separated list of (a,b) character-offset pairs
+into the submitted phrase, which we map onto the source via
+`neocaml-utop--error-target' and underline.  Offsets are clamped to the
+phrase bounds so the appended `;;' (or an end-of-input error) cannot
+push a span past the source buffer."
+  (neocaml-utop--clear-overlays)
+  (when (and (not (string-empty-p arg)) neocaml-utop--error-target)
+    (let* ((buf (nth 0 neocaml-utop--error-target))
+           (start (nth 1 neocaml-utop--error-target))
+           (end (nth 2 neocaml-utop--error-target))
+           (nums (mapcar #'string-to-number (split-string arg "," t)))
+           (overlays nil))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf
+          (let ((limit (min end (point-max))))
+            (while (>= (length nums) 2)
+              (let* ((a (pop nums))
+                     (b (pop nums))
+                     ;; utop reports character offsets, so map by simple
+                     ;; addition; clamp to the phrase to stay in bounds.
+                     (beg (max start (min (+ start a) limit)))
+                     (ovend (max start (min (+ start b) limit))))
+                (when (< beg ovend)
+                  (let ((ov (make-overlay beg ovend)))
+                    (overlay-put ov 'face 'neocaml-utop-error-face)
+                    (overlay-put ov 'help-echo "neocaml-utop: error here")
+                    (push ov overlays))))))))
+      ;; Store back in the transcript buffer (we're running in its filter).
+      (setq neocaml-utop--overlays overlays))))
+
+;;;; Protocol parsing
+
+(defun neocaml-utop--prompt-string ()
+  "Return the prompt string for the next phrase, advancing the counter."
+  (setq neocaml-utop--count (1+ neocaml-utop--count))
+  (format "utop[%d]> " neocaml-utop--count))
+
+(defun neocaml-utop--handle-line (line)
+  "Interpret one protocol LINE and return the text to insert (maybe \"\")."
+  (let* ((idx (string-search ":" line))
+         (cmd (if idx (substring line 0 idx) line))
+         (arg (if idx (substring line (1+ idx)) "")))
+    (pcase cmd
+      ("stdout" (concat arg "\n"))
+      ("stderr" (concat (propertize arg 'face 'font-lock-warning-face) "\n"))
+      ("prompt" (neocaml-utop--prompt-string))
+      ("accept" (neocaml-utop--handle-accept arg) "")
+      ("completion-start"
+       (setq neocaml-utop--completions nil
+             neocaml-utop--completion-state 'collecting)
+       "")
+      ("completion" (push arg neocaml-utop--completions) "")
+      ("completion-stop" (setq neocaml-utop--completion-state 'done) "")
+      ("no-such-package"
+       (concat (propertize (format "No such package: %s" arg)
+                           'face 'font-lock-warning-face)
+               "\n"))
+      ;; Control/metadata messages with nothing to display.
+      ((or "protocol-version" "phrase-terminator" "continue"
+           "history-data" "history-end" "history-bound")
+       "")
+      (_ ""))))
+
+(defun neocaml-utop--preoutput (string)
+  "Parse protocol STRING from utop and return the human-visible text.
+Installed in `comint-preoutput-filter-functions'."
+  (setq neocaml-utop--partial (concat neocaml-utop--partial string))
+  (let ((lines (split-string neocaml-utop--partial "\n"))
+        (out ""))
+    ;; The last element is an incomplete line (or "" if STRING ended in \n).
+    (setq neocaml-utop--partial (car (last lines)))
+    (dolist (line (butlast lines))
+      (setq out (concat out (neocaml-utop--handle-line line))))
+    out))
+
+;;;; Sending phrases
+
+(defun neocaml-utop--send-data (proc text)
+  "Send TEXT to PROC as a protocol data block (`data:' lines then `end:')."
+  (dolist (line (split-string text "\n"))
+    (process-send-string proc (concat "data:" line "\n")))
+  (process-send-string proc "end:\n"))
+
+(defun neocaml-utop--send-eval (proc text)
+  "Send TEXT to PROC as a single phrase, appending `;;' when missing.
+The terminator is required: without it utop reports a syntax error at
+end of input rather than waiting for more."
+  (let ((payload (if (string-suffix-p ";;" (string-trim-right text))
+                     text
+                   (concat text ";;"))))
+    (process-send-string proc "input:add-to-history\n")
+    (neocaml-utop--send-data proc payload)))
+
+(defun neocaml-utop--input-sender (proc input)
+  "Comint input sender: evaluate INPUT typed in the transcript.
+Records the input's buffer span so error offsets land on it."
+  (with-current-buffer (process-buffer proc)
+    (let ((start (marker-position comint-last-input-start)))
+      (setq neocaml-utop--error-target
+            (list (current-buffer) start (+ start (length input))))))
+  (neocaml-utop--send-eval proc input))
+
+;;;; Completion
+
+(defun neocaml-utop--complete (input)
+  "Ask utop to complete INPUT and return the candidate list.
+Blocks (briefly) waiting for the protocol round-trip."
+  (let ((proc (get-buffer-process (current-buffer))))
+    (when (process-live-p proc)
+      (setq neocaml-utop--completions nil
+            neocaml-utop--completion-state 'collecting)
+      (process-send-string proc "complete-company:\n")
+      (neocaml-utop--send-data proc input)
+      (with-timeout (2 nil)
+        (while (eq neocaml-utop--completion-state 'collecting)
+          (accept-process-output proc 0.05)))
+      (nreverse neocaml-utop--completions))))
+
+(defun neocaml-utop-completion-at-point ()
+  "Completion-at-point function backed by utop's completion engine.
+Active only in the transcript buffer, on the current input line."
+  (when (and neocaml-utop-completion-at-point
+             (derived-mode-p 'neocaml-utop-mode))
+    (let ((proc (get-buffer-process (current-buffer))))
+      (when (and (process-live-p proc)
+                 (>= (point) (comint-line-beginning-position)))
+        (let ((input (buffer-substring-no-properties
+                      (comint-line-beginning-position) (point))))
+          (when (> (length (string-trim input)) 0)
+            (let ((start (save-excursion
+                           (skip-chars-backward "A-Za-z0-9_'")
+                           (point)))
+                  (candidates (neocaml-utop--complete input)))
+              (when candidates
+                (neocaml-common-capf start (point) candidates "utop" 'text)))))))))
+
+;;;; Mode
+
+(defvar neocaml-utop-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map comint-mode-map)
+    (define-key map (kbd "C-c C-z") #'neocaml-utop-switch-to-source)
+    (easy-menu-define neocaml-utop-mode-menu map "utop Menu"
+      '("utop"
+        ["Switch to Source" neocaml-utop-switch-to-source
+         :help "Switch back to the source buffer that last invoked utop"]
+        "--"
+        ["Interrupt" neocaml-utop-interrupt
+         :enable (comint-check-proc (current-buffer))
+         :help "Interrupt the utop process"]
+        ["Restart" neocaml-utop-restart
+         :help "Kill and restart the utop toplevel"]
+        ["Clear Buffer" neocaml-utop-clear-buffer
+         :help "Erase the transcript buffer contents"]
+        "--"
+        ["Customize utop..." (customize-group 'neocaml-utop)
+         :help "Customize the neocaml-utop settings"]))
+    map)
+  "Keymap for `neocaml-utop-mode'.")
+
+(define-derived-mode neocaml-utop-mode comint-mode "utop"
+  "Major mode for the utop toplevel driven via its Emacs protocol.
+
+\\{neocaml-utop-mode-map}"
+  (setq-local comint-prompt-regexp neocaml-utop--prompt-regexp)
+  (setq-local comint-prompt-read-only t)
+  (setq-local comint-input-sender #'neocaml-utop--input-sender)
+  (setq-local comint-process-echoes nil)
+  (setq-local neocaml-utop--partial "")
+  (setq-local neocaml-utop--count -1)
+  (setq-local neocaml-utop--overlays nil)
+  (setq-local comment-start "(* ")
+  (setq-local comment-end " *)")
+  (setq-local comment-start-skip "(\\*+[ \t]*")
+  (setq-local font-lock-defaults '(neocaml-utop-font-lock-keywords t))
+  (add-hook 'comint-preoutput-filter-functions #'neocaml-utop--preoutput nil t)
+  (add-hook 'completion-at-point-functions
+            #'neocaml-utop-completion-at-point nil t)
+  (setq-local prettify-symbols-alist (neocaml--prettify-symbols-alist))
+  ;; Error overlays live in source buffers but are tracked here; drop them
+  ;; when this transcript is killed so they don't linger on the source.
+  (add-hook 'kill-buffer-hook #'neocaml-utop--clear-overlays nil t)
+  (when neocaml-utop-history-file
+    (setq-local comint-input-ring-file-name neocaml-utop-history-file)
+    (setq-local comint-input-ring-size neocaml-utop-history-size)
+    (setq-local comint-input-ignoredups t)
+    (comint-read-input-ring t)
+    (add-hook 'kill-buffer-hook #'comint-write-input-ring nil t)))
+
+;;;; Lifecycle
+
+(defun neocaml-utop--get-or-create (&optional command)
+  "Return the transcript buffer for the current context, starting it if needed.
+COMMAND, when given, is the (PROGRAM ARG...) to launch (used by
+`neocaml-utop-restart').  Otherwise it is computed here, while the
+current buffer is still the source one, so that directory-local settings
+like `neocaml-utop-flavor' are honored."
+  (let ((bufname (neocaml-utop--buffer-name))
+        (command (or command (neocaml-utop--command))))
+    (unless (comint-check-proc bufname)
+      (with-current-buffer (get-buffer-create bufname)
+        (unless (derived-mode-p 'neocaml-utop-mode)
+          (neocaml-utop-mode))
+        (setq neocaml-utop--partial "")
+        (setq neocaml-utop--count -1)
+        (setq neocaml-utop--command-line command)
+        (apply #'make-comint-in-buffer "neocaml-utop" (current-buffer)
+               (car command) nil (cdr command))))
+    (get-buffer bufname)))
+
+(defun neocaml-utop--ensure-process ()
+  "Return a live utop process for the current context, starting one if needed."
+  (get-buffer-process (neocaml-utop--get-or-create)))
+
+(defun neocaml-utop--process ()
+  "Return the running utop process for the current context, or nil."
+  (get-buffer-process (neocaml-utop--buffer-name)))
+
+(defun neocaml-utop--set-error-target (target)
+  "Record TARGET in the transcript buffer for the current context.
+TARGET is a (BUFFER START END) list, or nil when the next input is not
+source-derived (so no error overlay should be drawn)."
+  (when-let* ((buf (get-buffer (neocaml-utop--buffer-name))))
+    (with-current-buffer buf
+      (setq neocaml-utop--error-target target))))
+
+;;;###autoload
+(defun neocaml-utop-run ()
+  "Start a utop session for the current buffer's project, or switch to it."
+  (interactive)
+  (pop-to-buffer (neocaml-utop--get-or-create)))
+
+;;;###autoload
+(defun neocaml-utop-switch-to-utop ()
+  "Switch to the utop transcript, saving the current buffer as the source.
+Use \\[neocaml-utop-switch-to-source] in the transcript to return."
+  (interactive)
+  (let ((source (current-buffer))
+        (buffer (neocaml-utop--get-or-create)))
+    (with-current-buffer buffer
+      (setq neocaml-utop--source-buffer source))
+    (pop-to-buffer buffer)))
+
+(defun neocaml-utop-switch-to-source ()
+  "Switch from the transcript back to the source buffer that invoked it."
+  (interactive)
+  (if (and neocaml-utop--source-buffer
+           (buffer-live-p neocaml-utop--source-buffer))
+      (pop-to-buffer neocaml-utop--source-buffer)
+    (message "No source buffer to return to")))
+
+(defun neocaml-utop-interrupt ()
+  "Interrupt the utop process for the current context."
+  (interactive)
+  (when-let* ((proc (neocaml-utop--process)))
+    (interrupt-process proc)))
+
+;;;###autoload
+(defun neocaml-utop-restart ()
+  "Kill and restart the utop toplevel for the current buffer's project.
+The same toplevel command is reused, so a `dune-utop' session comes back
+as `dune-utop' even though restart runs from the transcript buffer."
+  (interactive)
+  (let* ((bufname (neocaml-utop--buffer-name))
+         (buf (get-buffer bufname))
+         (command (and buf (buffer-local-value 'neocaml-utop--command-line buf))))
+    (when (comint-check-proc bufname)
+      (let ((proc (get-buffer-process bufname)))
+        (set-process-query-on-exit-flag proc nil)
+        (delete-process proc)))
+    (pop-to-buffer (neocaml-utop--get-or-create command))))
+
+(defun neocaml-utop-clear-buffer ()
+  "Erase the utop transcript buffer for the current context.
+Works whether or not the toplevel is still running."
+  (interactive)
+  (when-let* ((buf (get-buffer (neocaml-utop--buffer-name))))
+    (with-current-buffer buf
+      (if (comint-check-proc buf)
+          (comint-clear-buffer)
+        (let ((inhibit-read-only t))
+          (erase-buffer))))))
+
+(defun neocaml-utop-quit ()
+  "Ask the utop session to exit."
+  (interactive)
+  (when-let* ((proc (neocaml-utop--process)))
+    (process-send-string proc "exit:0\n")))
+
+;;;; Sending source to utop
+
+;;;###autoload
+(defun neocaml-utop-send-region (start end)
+  "Send the region between START and END to utop for evaluation."
+  (interactive "r")
+  (let ((proc (neocaml-utop--ensure-process))
+        (source (current-buffer)))
+    (neocaml-utop--set-error-target (list source start end))
+    (neocaml-utop--send-eval proc (buffer-substring-no-properties start end))
+    (pulse-momentary-highlight-region start end)))
+
+;;;###autoload
+(defun neocaml-utop-send-buffer ()
+  "Send the entire buffer to utop."
+  (interactive)
+  (neocaml-utop-send-region (point-min) (point-max)))
+
+;;;###autoload
+(defun neocaml-utop-send-definition ()
+  "Send the definition at point to utop."
+  (interactive)
+  (if-let* ((node (treesit-defun-at-point))
+            (start (treesit-node-start node))
+            (end (treesit-node-end node)))
+      (neocaml-utop-send-region start end)
+    (user-error "No definition at point")))
+
+;;;###autoload
+(defun neocaml-utop-send-phrase ()
+  "Send the phrase at point (code between `;;') to utop."
+  (interactive)
+  (let ((bounds (neocaml-repl--phrase-bounds)))
+    (neocaml-utop-send-region (car bounds) (cdr bounds))))
+
+;;;###autoload
+(defun neocaml-utop-send-phrase-and-step ()
+  "Send the phrase at point to utop, then move to the next phrase."
+  (interactive)
+  (let ((bounds (neocaml-repl--phrase-bounds)))
+    (neocaml-utop-send-region (car bounds) (cdr bounds))
+    (goto-char (cdr bounds))
+    (skip-chars-forward " \t\n")))
+
+;;;###autoload
+(defun neocaml-utop-load-file (file)
+  "Load FILE into utop via the `#use' directive."
+  (interactive (list (buffer-file-name)))
+  (unless file
+    (user-error "Buffer is not visiting a file"))
+  (let ((proc (neocaml-utop--ensure-process)))
+    ;; Not a source region: clear any stale target so a #use error can't
+    ;; underline unrelated code in a previously evaluated buffer.
+    (neocaml-utop--set-error-target nil)
+    (neocaml-utop--send-eval proc (format "#use %S" file))))
+
+;;;###autoload
+(defun neocaml-utop-require (package)
+  "Load the findlib PACKAGE into utop via the `#require' directive."
+  (interactive (list (read-string "Require package: ")))
+  (let ((proc (neocaml-utop--ensure-process)))
+    (neocaml-utop--set-error-target nil)
+    (neocaml-utop--send-eval proc (format "#require %S" package))))
+
+;;;; Source-buffer minor mode
+
+(defvar neocaml-utop-minor-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-z") #'neocaml-utop-switch-to-utop)
+    (define-key map (kbd "C-c C-c") #'neocaml-utop-send-definition)
+    (define-key map (kbd "C-c C-r") #'neocaml-utop-send-region)
+    (define-key map (kbd "C-c C-b") #'neocaml-utop-send-buffer)
+    (define-key map (kbd "C-c C-p") #'neocaml-utop-send-phrase)
+    (define-key map (kbd "C-c C-n") #'neocaml-utop-send-phrase-and-step)
+    (define-key map (kbd "C-c C-l") #'neocaml-utop-load-file)
+    (define-key map (kbd "C-c C-i") #'neocaml-utop-interrupt)
+    (define-key map (kbd "C-c C-k") #'neocaml-utop-clear-buffer)
+    (easy-menu-define neocaml-utop-minor-mode-menu map "utop Menu"
+      '("utop"
+        ["Start/Switch to utop" neocaml-utop-switch-to-utop
+         :help "Start utop or switch to a running session"]
+        "--"
+        ["Send Definition" neocaml-utop-send-definition
+         :help "Send the definition at point to utop"]
+        ["Send Region" neocaml-utop-send-region
+         :enable (use-region-p)
+         :help "Send the active region to utop"]
+        ["Send Buffer" neocaml-utop-send-buffer
+         :help "Send the whole buffer to utop"]
+        ["Send Phrase" neocaml-utop-send-phrase
+         :help "Send the phrase at point to utop"]
+        ["Send Phrase and Step" neocaml-utop-send-phrase-and-step
+         :help "Send the phrase at point, then move to the next phrase"]
+        ["Load File" neocaml-utop-load-file
+         :help "Load a file into utop with #use"]
+        ["Require Package..." neocaml-utop-require
+         :help "Load a findlib package into utop with #require"]
+        "--"
+        ["Interrupt utop" neocaml-utop-interrupt
+         :enable (comint-check-proc (neocaml-utop--buffer-name))
+         :help "Interrupt the utop process"]
+        ["Clear utop Buffer" neocaml-utop-clear-buffer
+         :help "Erase the transcript buffer contents"]))
+    map)
+  "Keymap for `neocaml-utop-minor-mode'.")
+
+;;;###autoload
+(define-minor-mode neocaml-utop-minor-mode
+  "Minor mode for interacting with utop via its Emacs protocol.
+
+\\{neocaml-utop-minor-mode-map}"
+  :init-value nil
+  :lighter " utop"
+  :keymap neocaml-utop-minor-mode-map
+  :group 'neocaml-utop)
+
+(provide 'neocaml-utop)
+
+;;; neocaml-utop.el ends here

--- a/neocaml-utop.el
+++ b/neocaml-utop.el
@@ -129,11 +129,24 @@ the full output still goes to the transcript buffer."
   :type 'boolean
   :package-version '(neocaml . "0.10.0"))
 
+(defcustom neocaml-utop-inline-eval-result t
+  "When non-nil, show a source evaluation's value inline in the source buffer.
+The value is shown as a CIDER-style `=> ...' overlay at the end of the
+evaluated region; it is removed on the next evaluation or when the
+underlying text is edited."
+  :type 'boolean
+  :package-version '(neocaml . "0.10.0"))
+
 (defface neocaml-utop-error-face
   '((((supports :underline (:style wave)))
      :underline (:style wave :color "Red1"))
     (t :inherit error))
   "Face used to underline utop error spans in the source buffer."
+  :group 'neocaml-utop)
+
+(defface neocaml-utop-result-face
+  '((t :inherit shadow))
+  "Face for the inline `=>' result overlay in the source buffer."
   :group 'neocaml-utop)
 
 (defconst neocaml-utop--prompt-regexp "^utop\\[[0-9]+\\]> "
@@ -167,6 +180,15 @@ span past the source.  Nil when the last input was not source-derived
 
 (defvar-local neocaml-utop--overlays nil
   "Error overlays currently shown for the last evaluated phrase.")
+
+(defvar-local neocaml-utop--error-pending nil
+  "Error overlays awaiting their message text from the following stderr.")
+
+(defvar-local neocaml-utop--error-message ""
+  "Accumulated error text for the overlays in `neocaml-utop--error-pending'.")
+
+(defvar-local neocaml-utop--result-overlays nil
+  "Inline result overlays (the CIDER-style `=>') shown in source buffers.")
 
 (defvar-local neocaml-utop--echo nil
   "When non-nil, capture this evaluation's output for minibuffer echo.
@@ -222,10 +244,18 @@ is the per-project session derived from `neocaml-utop-buffer-name'."
 
 ;;;; Error overlays
 
+(defun neocaml-utop--overlay-evaporate (ov after &rest _)
+  "Delete OV when the text under it is edited.
+Used as an overlay modification hook; AFTER is non-nil on the call made
+after the change, which is when we remove the overlay."
+  (when after (delete-overlay ov)))
+
 (defun neocaml-utop--clear-overlays ()
   "Remove the error overlays tracked in this transcript buffer."
   (mapc #'delete-overlay neocaml-utop--overlays)
-  (setq neocaml-utop--overlays nil))
+  (setq neocaml-utop--overlays nil
+        neocaml-utop--error-pending nil
+        neocaml-utop--error-message ""))
 
 (defun neocaml-utop--handle-accept (arg)
   "Handle an `accept:ARG' message: ARG is empty on success.
@@ -233,7 +263,9 @@ Otherwise ARG is a comma-separated list of (a,b) character-offset pairs
 into the submitted phrase, which we map onto the source via
 `neocaml-utop--error-target' and underline.  Offsets are clamped to the
 phrase bounds so the appended `;;' (or an end-of-input error) cannot
-push a span past the source buffer."
+push a span past the source buffer.  The overlays clear themselves when
+the underlying text is edited, and get the error message as a tooltip
+once the following stderr arrives."
   (neocaml-utop--clear-overlays)
   (when (and (not (string-empty-p arg)) neocaml-utop--error-target)
     (let* ((buf (nth 0 neocaml-utop--error-target))
@@ -255,21 +287,37 @@ push a span past the source buffer."
                   (let ((ov (make-overlay beg ovend)))
                     (overlay-put ov 'face 'neocaml-utop-error-face)
                     (overlay-put ov 'help-echo "neocaml-utop: error here")
+                    (overlay-put ov 'modification-hooks
+                                 (list #'neocaml-utop--overlay-evaporate))
                     (push ov overlays))))))))
-      ;; Store back in the transcript buffer (we're running in its filter).
-      (setq neocaml-utop--overlays overlays))))
+      ;; Store back in the transcript buffer (we're running in its filter);
+      ;; the message text follows on stderr (see `neocaml-utop--handle-line').
+      (setq neocaml-utop--overlays overlays
+            neocaml-utop--error-pending overlays
+            neocaml-utop--error-message ""))))
 
-;;;; Result echo
+(defun neocaml-utop--note-error-text (text)
+  "Append TEXT to the pending error message and refresh overlay tooltips."
+  (when neocaml-utop--error-pending
+    (setq neocaml-utop--error-message
+          (if (string-empty-p neocaml-utop--error-message)
+              text
+            (concat neocaml-utop--error-message "\n" text)))
+    (dolist (ov neocaml-utop--error-pending)
+      (when (overlay-buffer ov)
+        (overlay-put ov 'help-echo neocaml-utop--error-message)))))
+
+;;;; Result echo and inline display
 ;;
 ;; utop's evaluated value is written to its redirected stdout, which
 ;; reaches us on a different channel than the command messages and can
 ;; land just *after* the terminating `prompt' (errors, sent inline, land
 ;; before it).  So rather than bound the capture on the prompt, we
 ;; debounce: each output line refreshes a short timer, and the result is
-;; echoed once output settles.
+;; shown once output settles.
 
 (defconst neocaml-utop--echo-settle-delay 0.2
-  "Seconds of output quiet before a captured result is echoed.")
+  "Seconds of output quiet before a captured result is shown.")
 
 (defun neocaml-utop--echo-result (lines)
   "Echo captured LINES (each (KIND . TEXT)) in the minibuffer.
@@ -284,18 +332,55 @@ Error and warning text is highlighted; empty lines are dropped."
     (unless (string-empty-p text)
       (message "%s" text))))
 
+(defun neocaml-utop--clear-result-overlays ()
+  "Remove the inline result overlays tracked in this transcript buffer."
+  (mapc #'delete-overlay neocaml-utop--result-overlays)
+  (setq neocaml-utop--result-overlays nil))
+
+(defun neocaml-utop--inline-result (lines target transcript)
+  "Show the value from LINES inline at the end of TARGET's region.
+TARGET is the (BUFFER START END) of the evaluated source; nothing is
+shown for interactive input (TARGET in TRANSCRIPT), for errors, or when
+there is no value.  The overlay is tracked in TRANSCRIPT and clears
+itself when the underlying text is edited."
+  (let ((value (mapconcat #'cdr
+                          (seq-filter (lambda (l) (and (eq (car l) 'out)
+                                                       (not (string-empty-p (cdr l)))))
+                                      lines)
+                          " ")))
+    (when (and (consp target) (not (string-empty-p value)))
+      (let ((buf (nth 0 target))
+            (end (nth 2 target)))
+        (when (and (buffer-live-p buf) (not (eq buf transcript)))
+          (let ((ov (with-current-buffer buf
+                      (save-excursion
+                        (goto-char (min end (point-max)))
+                        (let ((o (make-overlay (line-end-position) (line-end-position))))
+                          (overlay-put o 'after-string
+                                       (propertize (concat "  => " value)
+                                                   'face 'neocaml-utop-result-face))
+                          (overlay-put o 'modification-hooks
+                                       (list #'neocaml-utop--overlay-evaporate))
+                          o)))))
+            (with-current-buffer transcript
+              (push ov neocaml-utop--result-overlays))))))))
+
 (defun neocaml-utop--echo-flush (buffer)
-  "Echo and clear BUFFER's pending echo capture."
+  "Show and clear BUFFER's pending result capture (echo and/or inline)."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
-      (let ((lines (nreverse neocaml-utop--echo-lines)))
+      (let ((lines (nreverse neocaml-utop--echo-lines))
+            (target neocaml-utop--error-target))
         (setq neocaml-utop--echo nil
               neocaml-utop--echo-lines nil
               neocaml-utop--echo-timer nil)
-        (neocaml-utop--echo-result lines)))))
+        (when neocaml-utop-echo-eval-result
+          (neocaml-utop--echo-result lines))
+        (when neocaml-utop-inline-eval-result
+          (neocaml-utop--inline-result lines target buffer))))))
 
 (defun neocaml-utop--echo-accumulate (kind text)
-  "Record a TEXT line of KIND for echo and (re)arm the settle timer."
+  "Record a TEXT line of KIND for the result capture and re-arm the timer."
   (when neocaml-utop--echo
     (push (cons kind text) neocaml-utop--echo-lines)
     (when (timerp neocaml-utop--echo-timer)
@@ -322,8 +407,11 @@ Error and warning text is highlighted; empty lines are dropped."
        (concat arg "\n"))
       ("stderr"
        (neocaml-utop--echo-accumulate 'err arg)
+       (neocaml-utop--note-error-text arg)
        (concat (propertize arg 'face 'font-lock-warning-face) "\n"))
-      ("prompt" (neocaml-utop--prompt-string))
+      ("prompt"
+       (setq neocaml-utop--error-pending nil)
+       (neocaml-utop--prompt-string))
       ("accept" (neocaml-utop--handle-accept arg) "")
       ("completion-start"
        (setq neocaml-utop--completions nil
@@ -362,23 +450,50 @@ Installed in `comint-preoutput-filter-functions'."
   (process-send-string proc "end:\n"))
 
 (defun neocaml-utop--send-eval (proc text)
-  "Send TEXT to PROC as a single phrase, appending `;;' when missing.
-The terminator is required: without it utop reports a syntax error at
-end of input rather than waiting for more."
+  "Send TEXT to PROC for evaluation, appending `;;' when missing.
+Uses the protocol's `input-multi' so a region or buffer containing
+several `;;'-separated phrases evaluates all of them, not just the
+first.  The terminator is required: without it utop reports a syntax
+error at end of input rather than waiting for more."
   (let ((payload (if (string-suffix-p ";;" (string-trim-right text))
                      text
                    (concat text ";;"))))
-    (process-send-string proc "input:add-to-history\n")
+    (process-send-string proc "input-multi:\n")
     (neocaml-utop--send-data proc payload)))
 
 (defun neocaml-utop--input-sender (proc input)
-  "Comint input sender: evaluate INPUT typed in the transcript.
+  "Comint input sender: send INPUT typed in the transcript to PROC.
 Records the input's buffer span so error offsets land on it."
   (with-current-buffer (process-buffer proc)
     (let ((start (marker-position comint-last-input-start)))
       (setq neocaml-utop--error-target
             (list (current-buffer) start (+ start (length input))))))
   (neocaml-utop--send-eval proc input))
+
+(defun neocaml-utop--phrase-complete-p (input)
+  "Return non-nil when INPUT is ready to submit to utop.
+True for empty input, a phrase terminated by `;;', or a toplevel
+directive (beginning with `#')."
+  (let ((trimmed (string-trim input)))
+    (or (string-empty-p trimmed)
+        (string-suffix-p ";;" (string-trim-right input))
+        (string-prefix-p "#" trimmed))))
+
+(defun neocaml-utop-return ()
+  "Submit the current input, or insert a newline if the phrase is incomplete.
+Bound to \\`RET' in the transcript: input is treated as complete (and
+submitted) when it ends with `;;' or is a toplevel directive (begins
+with `#'), letting you type multi-line phrases naturally.  Pressing
+\\`RET' on a blank trailing line submits regardless."
+  (interactive)
+  (let* ((proc (get-buffer-process (current-buffer)))
+         (input (and proc (buffer-substring-no-properties
+                           (process-mark proc) (point-max)))))
+    (if (or (null proc)
+            (neocaml-utop--phrase-complete-p input)
+            (save-excursion (beginning-of-line) (looking-at-p "[ \t]*$")))
+        (comint-send-input)
+      (newline))))
 
 ;;;; Completion
 
@@ -419,6 +534,7 @@ Active only in the transcript buffer, on the current input line."
 (defvar neocaml-utop-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map comint-mode-map)
+    (define-key map (kbd "RET") #'neocaml-utop-return)
     (define-key map (kbd "C-c C-z") #'neocaml-utop-switch-to-source)
     (easy-menu-define neocaml-utop-mode-menu map "utop Menu"
       '("utop"
@@ -449,6 +565,7 @@ Active only in the transcript buffer, on the current input line."
   (setq-local neocaml-utop--partial "")
   (setq-local neocaml-utop--count -1)
   (setq-local neocaml-utop--overlays nil)
+  (setq-local neocaml-utop--result-overlays nil)
   (setq-local comment-start "(* ")
   (setq-local comment-end " *)")
   (setq-local comment-start-skip "(\\*+[ \t]*")
@@ -457,9 +574,11 @@ Active only in the transcript buffer, on the current input line."
   (add-hook 'completion-at-point-functions
             #'neocaml-utop-completion-at-point nil t)
   (setq-local prettify-symbols-alist (neocaml--prettify-symbols-alist))
-  ;; Error overlays live in source buffers but are tracked here; drop them
-  ;; when this transcript is killed so they don't linger on the source.
+  ;; Error and inline-result overlays live in source buffers but are
+  ;; tracked here; drop them when this transcript is killed so they don't
+  ;; linger on the source.
   (add-hook 'kill-buffer-hook #'neocaml-utop--clear-overlays nil t)
+  (add-hook 'kill-buffer-hook #'neocaml-utop--clear-result-overlays nil t)
   (when neocaml-utop-history-file
     (setq-local comint-input-ring-file-name neocaml-utop-history-file)
     (setq-local comint-input-ring-size neocaml-utop-history-size)
@@ -505,13 +624,18 @@ source-derived (so no error overlay should be drawn)."
       (setq neocaml-utop--error-target target))))
 
 (defun neocaml-utop--arm-echo ()
-  "Begin capturing the next evaluation's output for minibuffer echo.
-Honors `neocaml-utop-echo-eval-result'."
+  "Begin capturing the next evaluation's output for result display.
+Capture runs when either `neocaml-utop-echo-eval-result' or
+`neocaml-utop-inline-eval-result' is enabled; the flush decides which
+display(s) to use.  Any inline overlay from a previous evaluation is
+cleared."
   (when-let* ((buf (get-buffer (neocaml-utop--buffer-name))))
     (with-current-buffer buf
       (when (timerp neocaml-utop--echo-timer)
         (cancel-timer neocaml-utop--echo-timer))
-      (setq neocaml-utop--echo neocaml-utop-echo-eval-result
+      (neocaml-utop--clear-result-overlays)
+      (setq neocaml-utop--echo (or neocaml-utop-echo-eval-result
+                                   neocaml-utop-inline-eval-result)
             neocaml-utop--echo-lines nil
             neocaml-utop--echo-timer nil))))
 

--- a/neocaml-utop.el
+++ b/neocaml-utop.el
@@ -121,6 +121,14 @@ protocol's `complete-company' request."
   :type 'boolean
   :package-version '(neocaml . "0.10.0"))
 
+(defcustom neocaml-utop-echo-eval-result t
+  "When non-nil, echo the result of a source evaluation in the minibuffer.
+This mirrors a SLIME/CIDER-style flow: sending a phrase or definition
+from a source buffer shows its value (or error) in the echo area, while
+the full output still goes to the transcript buffer."
+  :type 'boolean
+  :package-version '(neocaml . "0.10.0"))
+
 (defface neocaml-utop-error-face
   '((((supports :underline (:style wave)))
      :underline (:style wave :color "Red1"))
@@ -159,6 +167,18 @@ span past the source.  Nil when the last input was not source-derived
 
 (defvar-local neocaml-utop--overlays nil
   "Error overlays currently shown for the last evaluated phrase.")
+
+(defvar-local neocaml-utop--echo nil
+  "When non-nil, capture this evaluation's output for minibuffer echo.
+Set when a source evaluation is sent; cleared when its terminating
+`prompt' arrives and the result has been echoed.")
+
+(defvar-local neocaml-utop--echo-lines nil
+  "Accumulated (KIND . TEXT) output lines for the current echo capture.
+KIND is `out' (stdout) or `err' (stderr); the list is reversed.")
+
+(defvar-local neocaml-utop--echo-timer nil
+  "Debounce timer that flushes the echo capture once output settles.")
 
 (defvar-local neocaml-utop--completions nil
   "Completion candidates accumulated from the current `complete' request.")
@@ -239,6 +259,51 @@ push a span past the source buffer."
       ;; Store back in the transcript buffer (we're running in its filter).
       (setq neocaml-utop--overlays overlays))))
 
+;;;; Result echo
+;;
+;; utop's evaluated value is written to its redirected stdout, which
+;; reaches us on a different channel than the command messages and can
+;; land just *after* the terminating `prompt' (errors, sent inline, land
+;; before it).  So rather than bound the capture on the prompt, we
+;; debounce: each output line refreshes a short timer, and the result is
+;; echoed once output settles.
+
+(defconst neocaml-utop--echo-settle-delay 0.2
+  "Seconds of output quiet before a captured result is echoed.")
+
+(defun neocaml-utop--echo-result (lines)
+  "Echo captured LINES (each (KIND . TEXT)) in the minibuffer.
+Error and warning text is highlighted; empty lines are dropped."
+  (let* ((kept (seq-remove (lambda (l) (string-empty-p (cdr l))) lines))
+         (text (mapconcat
+                (lambda (l)
+                  (if (eq (car l) 'err)
+                      (propertize (cdr l) 'face 'font-lock-warning-face)
+                    (cdr l)))
+                kept "\n")))
+    (unless (string-empty-p text)
+      (message "%s" text))))
+
+(defun neocaml-utop--echo-flush (buffer)
+  "Echo and clear BUFFER's pending echo capture."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let ((lines (nreverse neocaml-utop--echo-lines)))
+        (setq neocaml-utop--echo nil
+              neocaml-utop--echo-lines nil
+              neocaml-utop--echo-timer nil)
+        (neocaml-utop--echo-result lines)))))
+
+(defun neocaml-utop--echo-accumulate (kind text)
+  "Record a TEXT line of KIND for echo and (re)arm the settle timer."
+  (when neocaml-utop--echo
+    (push (cons kind text) neocaml-utop--echo-lines)
+    (when (timerp neocaml-utop--echo-timer)
+      (cancel-timer neocaml-utop--echo-timer))
+    (setq neocaml-utop--echo-timer
+          (run-at-time neocaml-utop--echo-settle-delay nil
+                       #'neocaml-utop--echo-flush (current-buffer)))))
+
 ;;;; Protocol parsing
 
 (defun neocaml-utop--prompt-string ()
@@ -252,8 +317,12 @@ push a span past the source buffer."
          (cmd (if idx (substring line 0 idx) line))
          (arg (if idx (substring line (1+ idx)) "")))
     (pcase cmd
-      ("stdout" (concat arg "\n"))
-      ("stderr" (concat (propertize arg 'face 'font-lock-warning-face) "\n"))
+      ("stdout"
+       (neocaml-utop--echo-accumulate 'out arg)
+       (concat arg "\n"))
+      ("stderr"
+       (neocaml-utop--echo-accumulate 'err arg)
+       (concat (propertize arg 'face 'font-lock-warning-face) "\n"))
       ("prompt" (neocaml-utop--prompt-string))
       ("accept" (neocaml-utop--handle-accept arg) "")
       ("completion-start"
@@ -435,6 +504,17 @@ source-derived (so no error overlay should be drawn)."
     (with-current-buffer buf
       (setq neocaml-utop--error-target target))))
 
+(defun neocaml-utop--arm-echo ()
+  "Begin capturing the next evaluation's output for minibuffer echo.
+Honors `neocaml-utop-echo-eval-result'."
+  (when-let* ((buf (get-buffer (neocaml-utop--buffer-name))))
+    (with-current-buffer buf
+      (when (timerp neocaml-utop--echo-timer)
+        (cancel-timer neocaml-utop--echo-timer))
+      (setq neocaml-utop--echo neocaml-utop-echo-eval-result
+            neocaml-utop--echo-lines nil
+            neocaml-utop--echo-timer nil))))
+
 ;;;###autoload
 (defun neocaml-utop-run ()
   "Start a utop session for the current buffer's project, or switch to it."
@@ -507,6 +587,7 @@ Works whether or not the toplevel is still running."
   (let ((proc (neocaml-utop--ensure-process))
         (source (current-buffer)))
     (neocaml-utop--set-error-target (list source start end))
+    (neocaml-utop--arm-echo)
     (neocaml-utop--send-eval proc (buffer-substring-no-properties start end))
     (pulse-momentary-highlight-region start end)))
 

--- a/test/neocaml-utop-test.el
+++ b/test/neocaml-utop-test.el
@@ -68,21 +68,28 @@
                   (neocaml-utop--send-eval 'fake-proc text))
                 (nreverse captured)))
 
-      (it "wraps a phrase in input/data/end, appending `;;'"
+      (it "wraps a phrase in input-multi/data/end, appending `;;'"
         (expect (send "let x = 1")
-                :to-equal '("input:add-to-history\n"
+                :to-equal '("input-multi:\n"
                             "data:let x = 1;;\n"
                             "end:\n")))
 
       (it "does not double a present `;;'"
         (expect (send "let x = 1;;")
-                :to-equal '("input:add-to-history\n"
+                :to-equal '("input-multi:\n"
                             "data:let x = 1;;\n"
+                            "end:\n")))
+
+      (it "sends every phrase of a multi-phrase region"
+        ;; input-multi means both phrases evaluate, not just the first.
+        (expect (send "let x = 1;; let y = 2;;")
+                :to-equal '("input-multi:\n"
+                            "data:let x = 1;; let y = 2;;\n"
                             "end:\n")))
 
       (it "splits a multi-line phrase into one data line per line"
         (expect (send "let x =\n  1 + 1")
-                :to-equal '("input:add-to-history\n"
+                :to-equal '("input-multi:\n"
                             "data:let x =\n"
                             "data:  1 + 1;;\n"
                             "end:\n"))))))
@@ -255,7 +262,100 @@
               (neocaml-utop--handle-accept "")
               (expect neocaml-utop--overlays :to-be nil)))
         (kill-buffer source)
+        (kill-buffer transcript))))
+
+  (it "attaches the following stderr text as the overlay tooltip"
+    (let ((source (generate-new-buffer "src"))
+          (transcript (generate-new-buffer "tr")))
+      (unwind-protect
+          (progn
+            (with-current-buffer source (insert "let y = 1 + \"a\""))
+            (with-current-buffer transcript
+              (setq neocaml-utop--error-target (list source 1 999))
+              (neocaml-utop--handle-accept "12,15")
+              ;; the error message arrives next, on stderr
+              (neocaml-utop--handle-line "stderr:Error: This expression has type string")
+              (expect (overlay-get (car neocaml-utop--overlays) 'help-echo)
+                      :to-equal "Error: This expression has type string")))
+        (kill-buffer source)
+        (kill-buffer transcript))))
+
+  (it "clears an error overlay when the underlined text is edited"
+    (let ((source (generate-new-buffer "src"))
+          (transcript (generate-new-buffer "tr")))
+      (unwind-protect
+          (progn
+            (with-current-buffer source (insert "let y = 1 + \"a\""))
+            (with-current-buffer transcript
+              (setq neocaml-utop--error-target (list source 1 999))
+              (neocaml-utop--handle-accept "12,15"))
+            (let ((ov (car (buffer-local-value 'neocaml-utop--overlays transcript))))
+              (expect (overlay-buffer ov) :to-equal source)
+              ;; edit inside the underlined span
+              (with-current-buffer source
+                (goto-char 14)
+                (insert "X"))
+              (expect (overlay-buffer ov) :to-be nil)))
+        (kill-buffer source)
         (kill-buffer transcript)))))
+
+(describe "neocaml-utop inline result overlay"
+  (it "shows the value as an after-string at the region's end of line"
+    (let ((source (generate-new-buffer "src"))
+          (transcript (generate-new-buffer "tr")))
+      (unwind-protect
+          (progn
+            (with-current-buffer source (insert "let x = 1 + 1"))
+            (with-current-buffer transcript
+              (neocaml-utop--inline-result
+               '((out . "val x : int = 2")) (list source 1 14) transcript)
+              (expect (length neocaml-utop--result-overlays) :to-equal 1)
+              (let ((ov (car neocaml-utop--result-overlays)))
+                (expect (overlay-buffer ov) :to-equal source)
+                (expect (overlay-get ov 'after-string)
+                        :to-equal (propertize "  => val x : int = 2"
+                                              'face 'neocaml-utop-result-face)))))
+        (kill-buffer source)
+        (kill-buffer transcript))))
+
+  (it "shows nothing for interactive input (target is the transcript)"
+    (let ((transcript (generate-new-buffer "tr")))
+      (unwind-protect
+          (with-current-buffer transcript
+            (insert "let x = 1 + 1")
+            (neocaml-utop--inline-result
+             '((out . "val x : int = 2")) (list transcript 1 14) transcript)
+            (expect neocaml-utop--result-overlays :to-be nil))
+        (kill-buffer transcript))))
+
+  (it "shows nothing when the result is only an error"
+    (let ((source (generate-new-buffer "src"))
+          (transcript (generate-new-buffer "tr")))
+      (unwind-protect
+          (progn
+            (with-current-buffer source (insert "let x = 1"))
+            (with-current-buffer transcript
+              (neocaml-utop--inline-result
+               '((err . "Error: boom")) (list source 1 10) transcript)
+              (expect neocaml-utop--result-overlays :to-be nil)))
+        (kill-buffer source)
+        (kill-buffer transcript)))))
+
+(describe "neocaml-utop input completeness"
+  (it "treats a `;;'-terminated phrase as complete"
+    (expect (neocaml-utop--phrase-complete-p "let x = 1;;") :to-be-truthy)
+    (expect (neocaml-utop--phrase-complete-p "let x = 1;;\n  ") :to-be-truthy))
+
+  (it "treats a toplevel directive as complete"
+    (expect (neocaml-utop--phrase-complete-p "#use \"foo.ml\"") :to-be-truthy)
+    (expect (neocaml-utop--phrase-complete-p "  #require \"str\"") :to-be-truthy))
+
+  (it "treats empty input as complete"
+    (expect (neocaml-utop--phrase-complete-p "   ") :to-be-truthy))
+
+  (it "treats an unterminated phrase as incomplete"
+    (expect (neocaml-utop--phrase-complete-p "let x =") :not :to-be-truthy)
+    (expect (neocaml-utop--phrase-complete-p "let x = 1") :not :to-be-truthy)))
 
 ;;;; Live integration against a real utop -emacs process
 
@@ -293,6 +393,24 @@
                       :to-be-truthy)
               (neocaml-utop-send-region (point-min) (point-max))
               (expect (wait (lambda () (string-match-p "val x : int = 2" (contents transcript))))
+                      :to-be-truthy))
+          (cleanup transcript source))))
+
+    (it "evaluates every phrase of a multi-phrase region"
+      ;; Regression: with plain `input' only the first phrase ran.
+      (let ((neocaml-utop-history-file nil)
+            (source (generate-new-buffer "src.ml"))
+            transcript)
+        (unwind-protect
+            (with-current-buffer source
+              (insert "let x = 1;; let y = 2;;")
+              (setq transcript (neocaml-utop--get-or-create))
+              (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
+                      :to-be-truthy)
+              (neocaml-utop-send-region (point-min) (point-max))
+              (expect (wait (lambda ()
+                              (and (string-match-p "val x : int = 1" (contents transcript))
+                                   (string-match-p "val y : int = 2" (contents transcript)))))
                       :to-be-truthy))
           (cleanup transcript source))))
 

--- a/test/neocaml-utop-test.el
+++ b/test/neocaml-utop-test.el
@@ -135,6 +135,54 @@
       (expect neocaml-utop--completion-state :to-equal 'done)
       (expect (reverse neocaml-utop--completions) :to-equal '("map" "map2")))))
 
+(describe "neocaml-utop result echo"
+  (cl-flet ((capture-message (thunk)
+              (let (captured)
+                (cl-letf (((symbol-function 'message)
+                           (lambda (fmt &rest args)
+                             (when (stringp fmt)
+                               (setq captured (apply #'format fmt args))))))
+                  (funcall thunk))
+                captured)))
+
+    (it "captures output and echoes it when the capture is flushed"
+      (with-temp-buffer
+        (setq neocaml-utop--echo t neocaml-utop--echo-lines nil
+              neocaml-utop--echo-timer nil)
+        (neocaml-utop--handle-line "stdout:val x : int = 2")
+        (expect neocaml-utop--echo-lines :to-equal '((out . "val x : int = 2")))
+        ;; output arms a debounce timer; cancel it and flush synchronously
+        (expect (timerp neocaml-utop--echo-timer) :to-be-truthy)
+        (cancel-timer neocaml-utop--echo-timer)
+        (expect (capture-message
+                 (lambda () (neocaml-utop--echo-flush (current-buffer))))
+                :to-equal "val x : int = 2")
+        (expect neocaml-utop--echo :to-be nil)
+        (expect neocaml-utop--echo-lines :to-be nil)))
+
+    (it "echoes error text from stderr"
+      (with-temp-buffer
+        (setq neocaml-utop--echo t neocaml-utop--echo-lines nil
+              neocaml-utop--echo-timer nil)
+        (neocaml-utop--handle-line "stderr:Error: Unbound value foo")
+        (when (timerp neocaml-utop--echo-timer)
+          (cancel-timer neocaml-utop--echo-timer))
+        (expect (substring-no-properties
+                 (capture-message
+                  (lambda () (neocaml-utop--echo-flush (current-buffer)))))
+                :to-equal "Error: Unbound value foo")))
+
+    (it "does not capture when disarmed"
+      (with-temp-buffer
+        (setq neocaml-utop--echo nil neocaml-utop--echo-lines nil
+              neocaml-utop--echo-timer nil)
+        (neocaml-utop--handle-line "stdout:val x : int = 2")
+        (expect neocaml-utop--echo-lines :to-be nil)
+        (expect neocaml-utop--echo-timer :to-be nil)
+        (expect (capture-message
+                 (lambda () (neocaml-utop--echo-flush (current-buffer))))
+                :to-be nil)))))
+
 (describe "neocaml-utop error overlays"
   (it "underlines the exact character range reported by accept"
     (let ((source (generate-new-buffer "src"))
@@ -245,6 +293,28 @@
                       :to-be-truthy)
               (neocaml-utop-send-region (point-min) (point-max))
               (expect (wait (lambda () (string-match-p "val x : int = 2" (contents transcript))))
+                      :to-be-truthy))
+          (cleanup transcript source))))
+
+    (it "echoes a source evaluation's result in the minibuffer"
+      (let ((neocaml-utop-history-file nil)
+            (neocaml-utop-echo-eval-result t)
+            (source (generate-new-buffer "src.ml"))
+            transcript messages)
+        (unwind-protect
+            (with-current-buffer source
+              (insert "let x = 1 + 1")
+              (setq transcript (neocaml-utop--get-or-create))
+              (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
+                      :to-be-truthy)
+              (cl-letf (((symbol-function 'message)
+                         (lambda (fmt &rest args)
+                           (when (stringp fmt) (push (apply #'format fmt args) messages)))))
+                (neocaml-utop-send-region (point-min) (point-max))
+                (wait (lambda ()
+                        (seq-find (lambda (m) (string-match-p "val x : int = 2" m))
+                                  messages))))
+              (expect (seq-find (lambda (m) (string-match-p "val x : int = 2" m)) messages)
                       :to-be-truthy))
           (cleanup transcript source))))
 

--- a/test/neocaml-utop-test.el
+++ b/test/neocaml-utop-test.el
@@ -1,0 +1,290 @@
+;;; neocaml-utop-test.el --- Tests for neocaml-utop -*- lexical-binding: t; -*-
+
+;; Copyright © 2025-2026 Bozhidar Batsov
+
+;;; Commentary:
+
+;; Buttercup tests for `neocaml-utop'.  The bulk of the suite exercises
+;; the protocol layer (line parsing, the preoutput filter, the input
+;; sender, prompt numbering, error-offset overlays and completion
+;; accumulation) without spawning utop.  A final block runs against a
+;; real `utop -emacs' process and is skipped when utop is not installed.
+
+;;; Code:
+
+(require 'neocaml-test-helpers)
+(require 'neocaml-utop)
+(require 'cl-lib)
+
+(describe "neocaml-utop prompt regex"
+  (it "matches the numbered utop prompt"
+    (expect (string-match-p neocaml-utop--prompt-regexp "utop[0]> ") :to-be-truthy)
+    (expect (string-match-p neocaml-utop--prompt-regexp "utop[42]> ") :to-be-truthy))
+
+  (it "anchors at beginning of line and ignores unrelated text"
+    (expect (string-match-p neocaml-utop--prompt-regexp "  utop[0]> ") :not :to-be-truthy)
+    (expect (string-match-p neocaml-utop--prompt-regexp "val x : int") :not :to-be-truthy)))
+
+(describe "neocaml-utop command construction"
+  (it "appends -emacs for the plain utop flavor"
+    (let ((neocaml-utop-flavor 'utop)
+          (neocaml-utop-program "utop")
+          (neocaml-utop-program-args nil))
+      (expect (neocaml-utop--command) :to-equal '("utop" "-emacs"))))
+
+  (it "keeps extra program args before -emacs"
+    (let ((neocaml-utop-flavor 'utop)
+          (neocaml-utop-program "utop")
+          (neocaml-utop-program-args '("-short-paths")))
+      (expect (neocaml-utop--command) :to-equal '("utop" "-short-paths" "-emacs"))))
+
+  (it "builds a dune utop command terminated by -emacs"
+    (let* ((neocaml-utop-flavor 'dune-utop)
+           (neocaml-utop-program-args nil)
+           (cmd (neocaml-utop--command)))
+      (expect (car cmd) :to-equal "dune")
+      (expect (cadr cmd) :to-equal "utop")
+      (expect (member "--" cmd) :to-be-truthy)
+      (expect (car (last cmd)) :to-equal "-emacs"))))
+
+(describe "neocaml-utop buffer naming"
+  (it "uses the base name when there is no project"
+    (cl-letf (((symbol-function 'neocaml-repl--project-id) (lambda () nil)))
+      (let ((neocaml-utop-buffer-name "*utop*"))
+        (expect (neocaml-utop--buffer-name) :to-equal "*utop*"))))
+
+  (it "derives a per-project name from the base"
+    (cl-letf (((symbol-function 'neocaml-repl--project-id) (lambda () "proj")))
+      (let ((neocaml-utop-buffer-name "*utop*"))
+        (expect (neocaml-utop--buffer-name) :to-equal "*utop: proj*")))))
+
+(describe "neocaml-utop input sender protocol"
+  ;; Capture the bytes that would be written to the process.
+  (let (captured)
+    (cl-flet ((send (text)
+                (setq captured nil)
+                (cl-letf (((symbol-function 'process-send-string)
+                           (lambda (_proc str) (push str captured))))
+                  (neocaml-utop--send-eval 'fake-proc text))
+                (nreverse captured)))
+
+      (it "wraps a phrase in input/data/end, appending `;;'"
+        (expect (send "let x = 1")
+                :to-equal '("input:add-to-history\n"
+                            "data:let x = 1;;\n"
+                            "end:\n")))
+
+      (it "does not double a present `;;'"
+        (expect (send "let x = 1;;")
+                :to-equal '("input:add-to-history\n"
+                            "data:let x = 1;;\n"
+                            "end:\n")))
+
+      (it "splits a multi-line phrase into one data line per line"
+        (expect (send "let x =\n  1 + 1")
+                :to-equal '("input:add-to-history\n"
+                            "data:let x =\n"
+                            "data:  1 + 1;;\n"
+                            "end:\n"))))))
+
+(describe "neocaml-utop protocol line handling"
+  (it "renders stdout verbatim"
+    (with-temp-buffer
+      (expect (neocaml-utop--handle-line "stdout:val x : int = 2")
+              :to-equal "val x : int = 2\n")))
+
+  (it "faces stderr with the warning face"
+    (with-temp-buffer
+      (let ((out (neocaml-utop--handle-line "stderr:Error: boom")))
+        (expect out :to-equal "Error: boom\n")
+        (expect (get-text-property 0 'face out) :to-equal 'font-lock-warning-face))))
+
+  (it "numbers prompts, advancing the counter"
+    (with-temp-buffer
+      (setq neocaml-utop--count -1)
+      (expect (neocaml-utop--handle-line "prompt:") :to-equal "utop[0]> ")
+      (expect (neocaml-utop--handle-line "prompt:") :to-equal "utop[1]> ")))
+
+  (it "treats metadata messages as invisible"
+    (with-temp-buffer
+      (expect (neocaml-utop--handle-line "protocol-version:1") :to-equal "")
+      (expect (neocaml-utop--handle-line "phrase-terminator:;;") :to-equal "")
+      (expect (neocaml-utop--handle-line "continue:") :to-equal ""))))
+
+(describe "neocaml-utop preoutput filter"
+  (it "buffers a partial line until its newline arrives"
+    (with-temp-buffer
+      (setq neocaml-utop--partial "")
+      (expect (neocaml-utop--preoutput "stdout:hel") :to-equal "")
+      (expect (neocaml-utop--preoutput "lo\n") :to-equal "hello\n")))
+
+  (it "handles several messages in one chunk"
+    (with-temp-buffer
+      (setq neocaml-utop--partial "" neocaml-utop--count -1)
+      (expect (neocaml-utop--preoutput "stdout:a\nstdout:b\nprompt:\n")
+              :to-equal "a\nb\nutop[0]> "))))
+
+(describe "neocaml-utop completion accumulation"
+  (it "collects candidates between start and stop"
+    (with-temp-buffer
+      (neocaml-utop--handle-line "completion-start:")
+      (expect neocaml-utop--completion-state :to-equal 'collecting)
+      (neocaml-utop--handle-line "completion:map")
+      (neocaml-utop--handle-line "completion:map2")
+      (neocaml-utop--handle-line "completion-stop:")
+      (expect neocaml-utop--completion-state :to-equal 'done)
+      (expect (reverse neocaml-utop--completions) :to-equal '("map" "map2")))))
+
+(describe "neocaml-utop error overlays"
+  (it "underlines the exact character range reported by accept"
+    (let ((source (generate-new-buffer "src"))
+          (transcript (generate-new-buffer "tr")))
+      (unwind-protect
+          (progn
+            (with-current-buffer source
+              (insert "let y = 1 + \"a\""))
+            (with-current-buffer transcript
+              ;; (BUFFER START END): offsets are relative to position 1
+              (setq neocaml-utop--error-target (list source 1 999))
+              (neocaml-utop--handle-accept "12,15")
+              (expect (length neocaml-utop--overlays) :to-equal 1)
+              (let ((ov (car neocaml-utop--overlays)))
+                (expect (with-current-buffer source
+                          (buffer-substring-no-properties
+                           (overlay-start ov) (overlay-end ov)))
+                        :to-equal "\"a\"")
+                (expect (overlay-get ov 'face) :to-equal 'neocaml-utop-error-face))))
+        (kill-buffer source)
+        (kill-buffer transcript))))
+
+  (it "maps character offsets correctly across multibyte source"
+    ;; utop reports character offsets, not bytes; a multibyte char before
+    ;; the error span must not shift the overlay.
+    (let ((source (generate-new-buffer "src"))
+          (transcript (generate-new-buffer "tr")))
+      (unwind-protect
+          (progn
+            (with-current-buffer source
+              (insert "let x = \"héllo\" + 1"))
+            (with-current-buffer transcript
+              (setq neocaml-utop--error-target (list source 1 999))
+              (neocaml-utop--handle-accept "8,15")
+              (expect (length neocaml-utop--overlays) :to-equal 1)
+              (let ((ov (car neocaml-utop--overlays)))
+                (expect (with-current-buffer source
+                          (buffer-substring-no-properties
+                           (overlay-start ov) (overlay-end ov)))
+                        :to-equal "\"héllo\""))))
+        (kill-buffer source)
+        (kill-buffer transcript))))
+
+  (it "does not crash or overshoot when offsets run past the phrase"
+    ;; `let x = 1 +' + appended `;;' makes utop report accept:11,13; with
+    ;; an 11-char source those offsets must clamp away rather than signal.
+    (let ((source (generate-new-buffer "src"))
+          (transcript (generate-new-buffer "tr")))
+      (unwind-protect
+          (progn
+            (with-current-buffer source (insert "let x = 1 +"))
+            (with-current-buffer transcript
+              (setq neocaml-utop--error-target
+                    (list source 1 (with-current-buffer source (point-max))))
+              (neocaml-utop--handle-accept "11,13")
+              (expect neocaml-utop--overlays :to-be nil)))
+        (kill-buffer source)
+        (kill-buffer transcript))))
+
+  (it "clears overlays on a clean accept"
+    (let ((source (generate-new-buffer "src"))
+          (transcript (generate-new-buffer "tr")))
+      (unwind-protect
+          (progn
+            (with-current-buffer source (insert "let y = 1 + \"a\""))
+            (with-current-buffer transcript
+              (setq neocaml-utop--error-target (list source 1 999))
+              (neocaml-utop--handle-accept "12,15")
+              (expect (length neocaml-utop--overlays) :to-equal 1)
+              (neocaml-utop--handle-accept "")
+              (expect neocaml-utop--overlays :to-be nil)))
+        (kill-buffer source)
+        (kill-buffer transcript)))))
+
+;;;; Live integration against a real utop -emacs process
+
+(describe "neocaml-utop live session"
+  (before-all
+    (unless (executable-find "utop")
+      (signal 'buttercup-pending "utop not installed")))
+
+  (cl-flet ((contents (buf)
+              (with-current-buffer buf
+                (buffer-substring-no-properties (point-min) (point-max))))
+            (wait (pred)
+              (let ((end (+ (float-time) 20)))
+                (while (and (not (funcall pred)) (< (float-time) end))
+                  (accept-process-output nil 0.05))
+                (funcall pred)))
+            (cleanup (transcript source)
+              (when (buffer-live-p transcript)
+                (when-let* ((proc (get-buffer-process transcript)))
+                  (set-process-query-on-exit-flag proc nil)
+                  (delete-process proc))
+                (kill-buffer transcript))
+              (when (buffer-live-p source) (kill-buffer source))))
+
+    (it "evaluates a phrase and shows the result"
+      ;; Bind the history file off so tests never touch the user's history.
+      (let ((neocaml-utop-history-file nil)
+            (source (generate-new-buffer "src.ml"))
+            transcript)
+        (unwind-protect
+            (with-current-buffer source
+              (insert "let x = 1 + 1")
+              (setq transcript (neocaml-utop--get-or-create))
+              (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
+                      :to-be-truthy)
+              (neocaml-utop-send-region (point-min) (point-max))
+              (expect (wait (lambda () (string-match-p "val x : int = 2" (contents transcript))))
+                      :to-be-truthy))
+          (cleanup transcript source))))
+
+    (it "underlines a type error precisely in the source"
+      (let ((neocaml-utop-history-file nil)
+            (source (generate-new-buffer "src.ml"))
+            transcript)
+        (unwind-protect
+            (with-current-buffer source
+              (insert "let y = 1 + \"a\"")
+              (setq transcript (neocaml-utop--get-or-create))
+              (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
+                      :to-be-truthy)
+              (neocaml-utop-send-region (point-min) (point-max))
+              (expect (wait (lambda () (string-match-p "type int" (contents transcript))))
+                      :to-be-truthy)
+              (let ((errs (seq-filter
+                           (lambda (o) (eq (overlay-get o 'face) 'neocaml-utop-error-face))
+                           (overlays-in (point-min) (point-max)))))
+                (expect (length errs) :to-equal 1)
+                (expect (buffer-substring-no-properties
+                         (overlay-start (car errs)) (overlay-end (car errs)))
+                        :to-equal "\"a\"")))
+          (cleanup transcript source))))
+
+    (it "returns completion candidates from utop"
+      (let ((neocaml-utop-history-file nil)
+            (source (generate-new-buffer "src.ml"))
+            transcript)
+        (unwind-protect
+            (with-current-buffer source
+              (setq transcript (neocaml-utop--get-or-create))
+              (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
+                      :to-be-truthy)
+              (with-current-buffer transcript
+                (goto-char (point-max))
+                (let ((cands (neocaml-utop--complete "List.ma")))
+                  (expect (member "map" cands) :to-be-truthy))))
+          (cleanup transcript source))))))
+
+(provide 'neocaml-utop-test)
+
+;;; neocaml-utop-test.el ends here


### PR DESCRIPTION
This adds `neocaml-utop`, an alternative toplevel backend that talks to utop over its native editor protocol (`utop -emacs`) instead of treating it as a plain comint stream the way `neocaml-repl` does.

Speaking the protocol is what makes it worthwhile: output, results, errors and warnings arrive already separated (no regexp sniffing), parse and type errors come with character ranges so we underline the exact offending sub-expression back in the source buffer (with the message as a tooltip), and completion is answered by utop's own engine. The transcript is still a comint derivative, so input editing, history and read-only prompts come for free - only the transport is custom (a preoutput filter that parses the protocol and an input sender that emits it).

On top of that it does SLIME/CIDER-style feedback: sending a phrase echoes its value in the minibuffer and shows it inline as a `=> ...` overlay, region/buffer sends evaluate every `;;`-separated phrase (via `input-multi`), and the transcript handles multi-line input.

`neocaml-repl` is untouched and stays the right choice for the plain `ocaml` toplevel, which has no protocol of its own. Enable `neocaml-utop-minor-mode` in OCaml buffers to use this; the keybindings mirror `neocaml-repl-minor-mode`.

Comes with unit and live-utop tests (the live ones skip when utop isn't installed). It grew out of poking at a possible mistty integration, so there's no issue to reference.