### PR TITLE
Adopt more buttercup idioms in the test suite

### DIFF
--- a/test/neocaml-build-test.el
+++ b/test/neocaml-build-test.el
@@ -13,30 +13,30 @@
 
 (describe "neocaml--resolve-build-path"
   (it "resolves dune-style _build/default/lib/foo.ml"
-    (cl-letf (((symbol-function 'file-readable-p)
-               (lambda (f) (string= f "/project/lib/foo.ml"))))
-      (expect (neocaml--resolve-build-path "/project/_build/default/lib/foo.ml")
-              :to-equal "/project/lib/foo.ml")))
+    (spy-on 'file-readable-p :and-call-fake
+            (lambda (f) (string= f "/project/lib/foo.ml")))
+    (expect (neocaml--resolve-build-path "/project/_build/default/lib/foo.ml")
+            :to-equal "/project/lib/foo.ml"))
 
   (it "resolves ocamlbuild-style _build/lib/foo.ml"
-    (cl-letf (((symbol-function 'file-readable-p)
-               (lambda (f) (string= f "/project/lib/foo.ml"))))
-      (expect (neocaml--resolve-build-path "/project/_build/lib/foo.ml")
-              :to-equal "/project/lib/foo.ml")))
+    (spy-on 'file-readable-p :and-call-fake
+            (lambda (f) (string= f "/project/lib/foo.ml")))
+    (expect (neocaml--resolve-build-path "/project/_build/lib/foo.ml")
+            :to-equal "/project/lib/foo.ml"))
 
   (it "returns nil for non-_build paths"
     (expect (neocaml--resolve-build-path "/project/lib/foo.ml")
             :to-be nil))
 
   (it "returns nil when no source file exists"
-    (cl-letf (((symbol-function 'file-readable-p) (lambda (_f) nil)))
-      (expect (neocaml--resolve-build-path "/project/_build/default/lib/foo.ml")
-              :to-be nil)))
+    (spy-on 'file-readable-p :and-return-value nil)
+    (expect (neocaml--resolve-build-path "/project/_build/default/lib/foo.ml")
+            :to-be nil))
 
   (it "prefers dune-style over ocamlbuild-style when both exist"
-    (cl-letf (((symbol-function 'file-readable-p) (lambda (_f) t)))
-      (expect (neocaml--resolve-build-path "/project/_build/default/lib/foo.ml")
-              :to-equal "/project/lib/foo.ml"))))
+    (spy-on 'file-readable-p :and-return-value t)
+    (expect (neocaml--resolve-build-path "/project/_build/default/lib/foo.ml")
+            :to-equal "/project/lib/foo.ml")))
 
 (describe "neocaml-redirect-build-files"
   (it "defaults to t"
@@ -47,42 +47,28 @@
             :to-equal #'booleanp)))
 
 (describe "neocaml--check-build-dir"
+  (before-each
+    (spy-on 'derived-mode-p :and-return-value t)
+    (spy-on 'y-or-n-p :and-return-value nil))
+
   (it "prompts to switch when visiting a _build/ file"
-    (let ((prompted nil))
-      (cl-letf (((symbol-function 'buffer-file-name)
-                 (lambda () "/project/_build/default/lib/foo.ml"))
-                ((symbol-function 'derived-mode-p)
-                 (lambda (&rest _) t))
-                ((symbol-function 'file-readable-p)
-                 (lambda (f) (string= f "/project/lib/foo.ml")))
-                ((symbol-function 'y-or-n-p)
-                 (lambda (_prompt) (setq prompted t) nil)))
-        (let ((neocaml-redirect-build-files t))
-          (neocaml--check-build-dir)
-          (expect prompted :to-be t)))))
+    (spy-on 'buffer-file-name :and-return-value "/project/_build/default/lib/foo.ml")
+    (spy-on 'file-readable-p :and-call-fake
+            (lambda (f) (string= f "/project/lib/foo.ml")))
+    (let ((neocaml-redirect-build-files t))
+      (neocaml--check-build-dir)
+      (expect 'y-or-n-p :to-have-been-called)))
 
   (it "does not prompt when neocaml-redirect-build-files is nil"
-    (let ((prompted nil))
-      (cl-letf (((symbol-function 'buffer-file-name)
-                 (lambda () "/project/_build/default/lib/foo.ml"))
-                ((symbol-function 'derived-mode-p)
-                 (lambda (&rest _) t))
-                ((symbol-function 'y-or-n-p)
-                 (lambda (_prompt) (setq prompted t) nil)))
-        (let ((neocaml-redirect-build-files nil))
-          (neocaml--check-build-dir)
-          (expect prompted :to-be nil)))))
+    (spy-on 'buffer-file-name :and-return-value "/project/_build/default/lib/foo.ml")
+    (let ((neocaml-redirect-build-files nil))
+      (neocaml--check-build-dir)
+      (expect 'y-or-n-p :not :to-have-been-called)))
 
   (it "does not prompt for non-_build/ files"
-    (let ((prompted nil))
-      (cl-letf (((symbol-function 'buffer-file-name)
-                 (lambda () "/project/lib/foo.ml"))
-                ((symbol-function 'derived-mode-p)
-                 (lambda (&rest _) t))
-                ((symbol-function 'y-or-n-p)
-                 (lambda (_prompt) (setq prompted t) nil)))
-        (let ((neocaml-redirect-build-files t))
-          (neocaml--check-build-dir)
-          (expect prompted :to-be nil))))))
+    (spy-on 'buffer-file-name :and-return-value "/project/lib/foo.ml")
+    (let ((neocaml-redirect-build-files t))
+      (neocaml--check-build-dir)
+      (expect 'y-or-n-p :not :to-have-been-called))))
 
 ;;; neocaml-build-test.el ends here

--- a/test/neocaml-dune-completion-test.el
+++ b/test/neocaml-dune-completion-test.el
@@ -145,11 +145,9 @@ Resolves both plain lists and dynamic completion tables."
               (make-directory (expand-file-name "sub" root))
               (write-region "(executable (name main))" nil
                             (expand-file-name "sub/dune" root))
-              (let ((libs (neocaml-dune--local-libraries root)))
-                (expect (member "my_lib" libs) :to-be-truthy)
-                (expect (member "my.pub" libs) :to-be-truthy)
-                ;; executable names are not library names
-                (expect (member "main" libs) :to-be nil)))
+              ;; exactly the library/public names, and not the executable
+              (expect (neocaml-dune--local-libraries root)
+                      :to-have-same-items-as '("my_lib" "my.pub")))
           (delete-directory root t))))
 
     (it "ignores dune files under _build"

--- a/test/neocaml-dune-test.el
+++ b/test/neocaml-dune-test.el
@@ -233,23 +233,23 @@ DESCRIPTION is the test name.  Uses `neocaml-dune-mode'."
     ;; prints `Entering directory' / `Leaving directory' markers on stderr
     ;; (issue #53).  Verify the call separates stderr from stdout so those
     ;; markers never end up in the formatted buffer.
-    (cl-letf (((symbol-function 'call-process-region)
-               (lambda (_start _end _program &optional _delete buffer
-                               _display &rest _args)
-                 (pcase-let ((`(,real-dest ,error-dest) buffer))
-                   (with-current-buffer real-dest
-                     (insert "(library\n (name foo))\n"))
-                   (with-temp-buffer
-                     (insert "Entering directory '/some/proj'\n"
-                             "Leaving directory '/some/proj'\n")
-                     (write-region nil nil error-dest nil 'no-message)))
-                 0)))
-      (with-temp-buffer
-        (insert "(library (name foo))")
-        (neocaml-dune-mode)
-        (neocaml-dune-format-buffer)
-        (expect (buffer-string)
-                :to-equal "(library\n (name foo))\n")))))
+    (spy-on 'call-process-region :and-call-fake
+            (lambda (_start _end _program &optional _delete buffer
+                            _display &rest _args)
+              (pcase-let ((`(,real-dest ,error-dest) buffer))
+                (with-current-buffer real-dest
+                  (insert "(library\n (name foo))\n"))
+                (with-temp-buffer
+                  (insert "Entering directory '/some/proj'\n"
+                          "Leaving directory '/some/proj'\n")
+                  (write-region nil nil error-dest nil 'no-message)))
+              0))
+    (with-temp-buffer
+      (insert "(library (name foo))")
+      (neocaml-dune-mode)
+      (neocaml-dune-format-buffer)
+      (expect (buffer-string)
+              :to-equal "(library\n (name foo))\n"))))
 
 (describe "neocaml-dune auto-mode-alist"
   (it "activates for dune files"

--- a/test/neocaml-objinfo-test.el
+++ b/test/neocaml-objinfo-test.el
@@ -148,48 +148,48 @@
 
   (describe "neocaml-objinfo--run"
     (it "errors when program is not found"
-      (cl-letf (((symbol-function 'executable-find) (lambda (_) nil)))
-        (with-temp-buffer
-          (expect (neocaml-objinfo--run "/tmp/test.cmi")
-                  :to-throw 'user-error))))
+      (spy-on 'executable-find :and-return-value nil)
+      (with-temp-buffer
+        (expect (neocaml-objinfo--run "/tmp/test.cmi")
+                :to-throw 'user-error)))
 
     (it "inserts error header on non-zero exit"
-      (cl-letf (((symbol-function 'executable-find) (lambda (_) t))
-                ((symbol-function 'call-process)
-                 (lambda (_program _infile _destination _display &rest _args)
-                   (insert "Error: not an OCaml object file\n")
-                   1)))
-        (with-temp-buffer
-          (neocaml-objinfo--run "/tmp/bad.cmi")
-          (expect (buffer-string) :to-match "exited with code 1")
-          (expect (buffer-string) :to-match "not an OCaml object file"))))
+      (spy-on 'executable-find :and-return-value t)
+      (spy-on 'call-process :and-call-fake
+              (lambda (&rest _)
+                (insert "Error: not an OCaml object file\n")
+                1))
+      (with-temp-buffer
+        (neocaml-objinfo--run "/tmp/bad.cmi")
+        (expect (buffer-string) :to-match "exited with code 1")
+        (expect (buffer-string) :to-match "not an OCaml object file")))
 
     (it "inserts output on success"
-      (cl-letf (((symbol-function 'executable-find) (lambda (_) t))
-                ((symbol-function 'call-process)
-                 (lambda (_program _infile _destination _display &rest _args)
-                   (insert "Unit name: Foo\n")
-                   0)))
-        (with-temp-buffer
-          (neocaml-objinfo--run "/tmp/foo.cmi")
-          (expect (buffer-string) :to-equal "Unit name: Foo\n")))))
+      (spy-on 'executable-find :and-return-value t)
+      (spy-on 'call-process :and-call-fake
+              (lambda (&rest _)
+                (insert "Unit name: Foo\n")
+                0))
+      (with-temp-buffer
+        (neocaml-objinfo--run "/tmp/foo.cmi")
+        (expect (buffer-string) :to-equal "Unit name: Foo\n"))))
 
   (describe "revert"
     (it "re-runs ocamlobjinfo on the stored file"
+      (spy-on 'executable-find :and-return-value t)
       (let ((run-count 0))
-        (cl-letf (((symbol-function 'executable-find) (lambda (_) t))
-                  ((symbol-function 'call-process)
-                   (lambda (_program _infile _destination _display &rest _args)
-                     (setq run-count (1+ run-count))
-                     (insert (format "Run %d\n" run-count))
-                     0)))
-          (with-temp-buffer
-            (setq neocaml-objinfo--file "/tmp/foo.cmi")
-            (neocaml-objinfo--run neocaml-objinfo--file)
-            (expect run-count :to-equal 1)
-            (neocaml-objinfo--run neocaml-objinfo--file)
-            (expect run-count :to-equal 2)
-            (expect (buffer-string) :to-equal "Run 2\n"))))))
+        (spy-on 'call-process :and-call-fake
+                (lambda (&rest _)
+                  (setq run-count (1+ run-count))
+                  (insert (format "Run %d\n" run-count))
+                  0))
+        (with-temp-buffer
+          (setq neocaml-objinfo--file "/tmp/foo.cmi")
+          (neocaml-objinfo--run neocaml-objinfo--file)
+          (expect 'call-process :to-have-been-called-times 1)
+          (neocaml-objinfo--run neocaml-objinfo--file)
+          (expect 'call-process :to-have-been-called-times 2)
+          (expect (buffer-string) :to-equal "Run 2\n")))))
 
   (describe "auto-mode-alist"
     (dolist (ext '(".cmi" ".cmo" ".cmx" ".cma" ".cmxa" ".cmxs" ".cmt" ".cmti"))

--- a/test/neocaml-repl-test.el
+++ b/test/neocaml-repl-test.el
@@ -105,123 +105,122 @@
         (expect (buffer-substring-no-properties pos (+ pos 2)) :to-equal ";;")))))
 
 (describe "neocaml-repl source-to-repl switch"
+  (after-each (neocaml-test-kill-tracked-buffers))
+
   (it "pops to an existing REPL buffer and records the source"
-    (let ((source (generate-new-buffer "*neocaml-repl-test-source*"))
-          (repl (get-buffer-create neocaml-repl-buffer-name)))
-      (unwind-protect
-          (with-current-buffer source
-            ;; Existing REPL has the same flavor as requested, so no restart prompt.
-            (with-current-buffer repl (setq neocaml-repl--flavor neocaml-repl-flavor))
-            (spy-on 'neocaml-repl--buffer :and-return-value neocaml-repl-buffer-name)
-            (spy-on 'comint-check-proc :and-return-value t)
-            (spy-on 'pop-to-buffer)
-            (neocaml-repl-switch-to-repl)
-            (expect 'pop-to-buffer :to-have-been-called-with neocaml-repl-buffer-name)
-            (expect (buffer-local-value 'neocaml-repl--source-buffer repl)
-                    :to-equal source))
-        (kill-buffer source)
-        (when (buffer-live-p repl) (kill-buffer repl)))))
+    (let ((source (neocaml-test-track-buffer
+                   (generate-new-buffer "*neocaml-repl-test-source*")))
+          (repl (neocaml-test-track-buffer
+                 (get-buffer-create neocaml-repl-buffer-name))))
+      (with-current-buffer source
+        ;; Existing REPL has the same flavor as requested, so no restart prompt.
+        (with-current-buffer repl (setq neocaml-repl--flavor neocaml-repl-flavor))
+        (spy-on 'neocaml-repl--buffer :and-return-value neocaml-repl-buffer-name)
+        (spy-on 'comint-check-proc :and-return-value t)
+        (spy-on 'pop-to-buffer)
+        (neocaml-repl-switch-to-repl)
+        (expect 'pop-to-buffer :to-have-been-called-with neocaml-repl-buffer-name)
+        (expect (buffer-local-value 'neocaml-repl--source-buffer repl)
+                :to-equal source))))
 
   (it "starts a new REPL when none is running and records the source"
-    (let ((source (generate-new-buffer "*neocaml-repl-test-source*"))
-          (repl (get-buffer-create neocaml-repl-buffer-name)))
-      (unwind-protect
-          (with-current-buffer source
-            (spy-on 'neocaml-repl--buffer :and-return-value neocaml-repl-buffer-name)
-            (spy-on 'comint-check-proc :and-return-value nil)
-            (spy-on 'neocaml-repl-start)
-            (neocaml-repl-switch-to-repl)
-            (expect 'neocaml-repl-start :to-have-been-called)
-            (expect (buffer-local-value 'neocaml-repl--source-buffer repl)
-                    :to-equal source))
-        (kill-buffer source)
-        (when (buffer-live-p repl) (kill-buffer repl)))))
+    (let ((source (neocaml-test-track-buffer
+                   (generate-new-buffer "*neocaml-repl-test-source*")))
+          (repl (neocaml-test-track-buffer
+                 (get-buffer-create neocaml-repl-buffer-name))))
+      (with-current-buffer source
+        (spy-on 'neocaml-repl--buffer :and-return-value neocaml-repl-buffer-name)
+        (spy-on 'comint-check-proc :and-return-value nil)
+        (spy-on 'neocaml-repl-start)
+        (neocaml-repl-switch-to-repl)
+        (expect 'neocaml-repl-start :to-have-been-called)
+        (expect (buffer-local-value 'neocaml-repl--source-buffer repl)
+                :to-equal source))))
 
   (it "offers to restart the REPL when the requested flavor differs"
-    (let ((source (generate-new-buffer "*neocaml-repl-test-source*"))
-          (repl (get-buffer-create neocaml-repl-buffer-name)))
-      (unwind-protect
-          (with-current-buffer source
-            (with-current-buffer repl (setq neocaml-repl--flavor 'ocaml))
-            (let ((neocaml-repl-flavor 'utop))
-              (spy-on 'neocaml-repl--buffer :and-return-value neocaml-repl-buffer-name)
-              (spy-on 'comint-check-proc :and-return-value t)
-              (spy-on 'y-or-n-p :and-return-value t)
-              (spy-on 'neocaml-repl--kill)
-              (spy-on 'neocaml-repl-start)
-              (neocaml-repl-switch-to-repl)
-              (expect 'neocaml-repl--kill :to-have-been-called)
-              (expect 'neocaml-repl-start :to-have-been-called)))
-        (kill-buffer source)
-        (when (buffer-live-p repl) (kill-buffer repl))))))
+    (let ((source (neocaml-test-track-buffer
+                   (generate-new-buffer "*neocaml-repl-test-source*")))
+          (repl (neocaml-test-track-buffer
+                 (get-buffer-create neocaml-repl-buffer-name))))
+      (with-current-buffer source
+        (with-current-buffer repl (setq neocaml-repl--flavor 'ocaml))
+        (let ((neocaml-repl-flavor 'utop))
+          (spy-on 'neocaml-repl--buffer :and-return-value neocaml-repl-buffer-name)
+          (spy-on 'comint-check-proc :and-return-value t)
+          (spy-on 'y-or-n-p :and-return-value t)
+          (spy-on 'neocaml-repl--kill)
+          (spy-on 'neocaml-repl-start)
+          (neocaml-repl-switch-to-repl)
+          (expect 'neocaml-repl--kill :to-have-been-called)
+          (expect 'neocaml-repl-start :to-have-been-called))))))
 
 (describe "neocaml-repl buffer switching"
+  (after-each (neocaml-test-kill-tracked-buffers))
+
   (it "pops to the saved source buffer"
-    (let ((source (generate-new-buffer "*neocaml-repl-test-source*"))
-          (repl (generate-new-buffer "*neocaml-repl-test-repl*")))
-      (unwind-protect
-          (with-current-buffer repl
-            (setq-local neocaml-repl--source-buffer source)
-            (spy-on 'pop-to-buffer)
-            (neocaml-repl-switch-to-source)
-            (expect 'pop-to-buffer :to-have-been-called-with source))
-        (kill-buffer source)
-        (kill-buffer repl))))
+    (let ((source (neocaml-test-track-buffer
+                   (generate-new-buffer "*neocaml-repl-test-source*")))
+          (repl (neocaml-test-track-buffer
+                 (generate-new-buffer "*neocaml-repl-test-repl*"))))
+      (with-current-buffer repl
+        (setq-local neocaml-repl--source-buffer source)
+        (spy-on 'pop-to-buffer)
+        (neocaml-repl-switch-to-source)
+        (expect 'pop-to-buffer :to-have-been-called-with source))))
 
   (it "messages when no source buffer is set"
-    (let ((repl (generate-new-buffer "*neocaml-repl-test-repl*")))
-      (unwind-protect
-          (with-current-buffer repl
-            (setq-local neocaml-repl--source-buffer nil)
-            (spy-on 'message)
-            (neocaml-repl-switch-to-source)
-            (expect 'message :to-have-been-called-with "No source buffer to return to"))
-        (kill-buffer repl))))
+    (let ((repl (neocaml-test-track-buffer
+                 (generate-new-buffer "*neocaml-repl-test-repl*"))))
+      (with-current-buffer repl
+        (setq-local neocaml-repl--source-buffer nil)
+        (spy-on 'message)
+        (neocaml-repl-switch-to-source)
+        (expect 'message :to-have-been-called-with "No source buffer to return to"))))
 
   (it "messages when the saved source buffer is dead"
-    (let ((source (generate-new-buffer "*neocaml-repl-test-source*"))
-          (repl (generate-new-buffer "*neocaml-repl-test-repl*")))
-      (unwind-protect
-          (with-current-buffer repl
-            (setq-local neocaml-repl--source-buffer source)
-            (kill-buffer source)
-            (spy-on 'message)
-            (neocaml-repl-switch-to-source)
-            (expect 'message :to-have-been-called-with "No source buffer to return to"))
-        (when (buffer-live-p repl) (kill-buffer repl))))))
+    (let ((source (neocaml-test-track-buffer
+                   (generate-new-buffer "*neocaml-repl-test-source*")))
+          (repl (neocaml-test-track-buffer
+                 (generate-new-buffer "*neocaml-repl-test-repl*"))))
+      (with-current-buffer repl
+        (setq-local neocaml-repl--source-buffer source)
+        (kill-buffer source)
+        (spy-on 'message)
+        (neocaml-repl-switch-to-source)
+        (expect 'message :to-have-been-called-with "No source buffer to return to")))))
 
 (describe "neocaml-repl--start-command"
+  (after-each (neocaml-test-kill-tracked-buffers))
+
   (it "records the flavor and command and sets the mode line"
-    (let ((repl "*neocaml-repl-startcmd-test*"))
-      (unwind-protect
-          (progn
-            (spy-on 'make-comint-in-buffer :and-call-fake
-                    (lambda (_name buffer &rest _) (get-buffer-create buffer)))
-            (spy-on 'neocaml-repl-mode)
-            (let ((buf (neocaml-repl--start-command repl '("utop") 'utop)))
-              (with-current-buffer buf
-                (expect neocaml-repl--flavor :to-equal 'utop)
-                (expect neocaml-repl--command-line :to-equal '("utop"))
-                (expect mode-name :to-equal "OCaml-REPL[utop]"))))
-        (when (get-buffer repl) (kill-buffer repl))))))
+    (spy-on 'make-comint-in-buffer :and-call-fake
+            (lambda (_name buffer &rest _) (get-buffer-create buffer)))
+    (spy-on 'neocaml-repl-mode)
+    (let ((buf (neocaml-test-track-buffer
+                (neocaml-repl--start-command "*neocaml-repl-startcmd-test*"
+                                             '("utop") 'utop))))
+      (with-current-buffer buf
+        (expect neocaml-repl--flavor :to-equal 'utop)
+        (expect neocaml-repl--command-line :to-equal '("utop"))
+        (expect mode-name :to-equal "OCaml-REPL[utop]")))))
 
 (describe "neocaml-repl restart"
+  (after-each (neocaml-test-kill-tracked-buffers))
+
   (it "relaunches with the recorded flavor and command"
-    (let ((repl (get-buffer-create "*neocaml-repl-restart-test*")))
-      (unwind-protect
-          (progn
-            (with-current-buffer repl
-              (setq-local neocaml-repl--flavor 'utop)
-              (setq-local neocaml-repl--command-line '("utop")))
-            (spy-on 'neocaml-repl--buffer :and-return-value "*neocaml-repl-restart-test*")
-            (spy-on 'neocaml-repl--kill)
-            (spy-on 'neocaml-repl--start-command)
-            (neocaml-repl-restart)
-            (expect 'neocaml-repl--kill
-                    :to-have-been-called-with "*neocaml-repl-restart-test*")
-            (expect 'neocaml-repl--start-command
-                    :to-have-been-called-with "*neocaml-repl-restart-test*" '("utop") 'utop))
-        (when (buffer-live-p repl) (kill-buffer repl)))))
+    (let ((repl (neocaml-test-track-buffer
+                 (get-buffer-create "*neocaml-repl-restart-test*"))))
+      (with-current-buffer repl
+        (setq-local neocaml-repl--flavor 'utop)
+        (setq-local neocaml-repl--command-line '("utop")))
+      (spy-on 'neocaml-repl--buffer :and-return-value "*neocaml-repl-restart-test*")
+      (spy-on 'neocaml-repl--kill)
+      (spy-on 'neocaml-repl--start-command)
+      (neocaml-repl-restart)
+      (expect 'neocaml-repl--kill
+              :to-have-been-called-with "*neocaml-repl-restart-test*")
+      (expect 'neocaml-repl--start-command
+              :to-have-been-called-with "*neocaml-repl-restart-test*" '("utop") 'utop)))
 
   (it "falls back to a fresh start when nothing was recorded"
     (spy-on 'neocaml-repl--buffer :and-return-value "*neocaml-repl-absent*")

--- a/test/neocaml-repl-test.el
+++ b/test/neocaml-repl-test.el
@@ -35,31 +35,29 @@
     (expect (string-match-p neocaml-repl--prompt-regexp "val x : int") :not :to-be-truthy)))
 
 (describe "neocaml-repl input sender"
-  ;; Stub out `comint-send-string' so we can capture what would be
-  ;; sent to the toplevel without a real process.
-  (let (captured)
-    (before-each (setq captured nil))
+  ;; Spy on `comint-send-string' to capture what would be sent to the
+  ;; toplevel without a real process.
+  (before-each (spy-on 'comint-send-string))
 
-    (cl-flet ((send (input)
-                (cl-letf (((symbol-function 'comint-send-string)
-                           (lambda (_proc str) (setq captured str))))
-                  (neocaml-repl--input-sender 'fake-proc input))
-                captured))
+  (cl-flet ((send (input)
+              (neocaml-repl--input-sender 'fake-proc input)
+              (nth 1 (spy-context-args
+                      (spy-calls-most-recent 'comint-send-string)))))
 
-      (it "appends `;;' and a newline when input is unterminated"
-        (expect (send "let x = 1") :to-equal "let x = 1\n;;\n"))
+    (it "appends `;;' and a newline when input is unterminated"
+      (expect (send "let x = 1") :to-equal "let x = 1\n;;\n"))
 
-      (it "leaves input alone when it already ends with `;;'"
-        (expect (send "let x = 1;;") :to-equal "let x = 1;;\n"))
+    (it "leaves input alone when it already ends with `;;'"
+      (expect (send "let x = 1;;") :to-equal "let x = 1;;\n"))
 
-      (it "treats trailing whitespace as still terminated"
-        (expect (send "let x = 1;;   ") :to-equal "let x = 1;;   \n")
-        (expect (send "let x = 1;;\n") :to-equal "let x = 1;;\n\n"))
+    (it "treats trailing whitespace as still terminated"
+      (expect (send "let x = 1;;   ") :to-equal "let x = 1;;   \n")
+      (expect (send "let x = 1;;\n") :to-equal "let x = 1;;\n\n"))
 
-      (it "does not get fooled by `;;' inside a string"
-        ;; The trailing-`;;' check is purely textual; if the literal
-        ;; last two chars aren't `;;' we must terminate.
-        (expect (send "let s = \";;\"") :to-equal "let s = \";;\"\n;;\n")))))
+    (it "does not get fooled by `;;' inside a string"
+      ;; The trailing-`;;' check is purely textual; if the literal
+      ;; last two chars aren't `;;' we must terminate.
+      (expect (send "let s = \";;\"") :to-equal "let s = \";;\"\n;;\n"))))
 
 (describe "neocaml-repl phrase delimiter search"
   (before-all

--- a/test/neocaml-test-helpers.el
+++ b/test/neocaml-test-helpers.el
@@ -14,6 +14,30 @@
 (require 'buttercup)
 (require 'neocaml)
 
+;;;; Buffer teardown
+
+(defvar neocaml-test--buffers nil
+  "Buffers registered for teardown after the current spec.")
+
+(defun neocaml-test-track-buffer (buffer)
+  "Register BUFFER (and any process it runs) for teardown, and return it.
+Pair with `neocaml-test-kill-tracked-buffers' in an `after-each' so specs
+can create buffers without hand-rolling `unwind-protect' cleanup."
+  (push buffer neocaml-test--buffers)
+  buffer)
+
+(defun neocaml-test-kill-tracked-buffers ()
+  "Kill the buffers registered with `neocaml-test-track-buffer'.
+Any live process in a tracked buffer is deleted first (without a
+query-on-exit prompt)."
+  (dolist (buffer neocaml-test--buffers)
+    (when (buffer-live-p buffer)
+      (when-let* ((proc (get-buffer-process buffer)))
+        (set-process-query-on-exit-flag proc nil)
+        (delete-process proc))
+      (kill-buffer buffer)))
+  (setq neocaml-test--buffers nil))
+
 ;;;; String helpers
 
 (defun neocaml-test--dedent (string)

--- a/test/neocaml-utop-test.el
+++ b/test/neocaml-utop-test.el
@@ -49,50 +49,49 @@
 
 (describe "neocaml-utop buffer naming"
   (it "uses the base name when there is no project"
-    (cl-letf (((symbol-function 'neocaml-repl--project-id) (lambda () nil)))
-      (let ((neocaml-utop-buffer-name "*utop*"))
-        (expect (neocaml-utop--buffer-name) :to-equal "*utop*"))))
+    (spy-on 'neocaml-repl--project-id :and-return-value nil)
+    (let ((neocaml-utop-buffer-name "*utop*"))
+      (expect (neocaml-utop--buffer-name) :to-equal "*utop*")))
 
   (it "derives a per-project name from the base"
-    (cl-letf (((symbol-function 'neocaml-repl--project-id) (lambda () "proj")))
-      (let ((neocaml-utop-buffer-name "*utop*"))
-        (expect (neocaml-utop--buffer-name) :to-equal "*utop: proj*")))))
+    (spy-on 'neocaml-repl--project-id :and-return-value "proj")
+    (let ((neocaml-utop-buffer-name "*utop*"))
+      (expect (neocaml-utop--buffer-name) :to-equal "*utop: proj*"))))
 
 (describe "neocaml-utop input sender protocol"
-  ;; Capture the bytes that would be written to the process.
-  (let (captured)
-    (cl-flet ((send (text)
-                (setq captured nil)
-                (cl-letf (((symbol-function 'process-send-string)
-                           (lambda (_proc str) (push str captured))))
-                  (neocaml-utop--send-eval 'fake-proc text))
-                (nreverse captured)))
+  ;; Spy on `process-send-string' to capture the bytes sent to the process.
+  (before-each (spy-on 'process-send-string))
 
-      (it "wraps a phrase in input-multi/data/end, appending `;;'"
-        (expect (send "let x = 1")
-                :to-equal '("input-multi:\n"
-                            "data:let x = 1;;\n"
-                            "end:\n")))
+  (cl-flet ((send (text)
+              (neocaml-utop--send-eval 'fake-proc text)
+              (mapcar (lambda (args) (nth 1 args))
+                      (spy-calls-all-args 'process-send-string))))
 
-      (it "does not double a present `;;'"
-        (expect (send "let x = 1;;")
-                :to-equal '("input-multi:\n"
-                            "data:let x = 1;;\n"
-                            "end:\n")))
+    (it "wraps a phrase in input-multi/data/end, appending `;;'"
+      (expect (send "let x = 1")
+              :to-equal '("input-multi:\n"
+                          "data:let x = 1;;\n"
+                          "end:\n")))
 
-      (it "sends every phrase of a multi-phrase region"
-        ;; input-multi means both phrases evaluate, not just the first.
-        (expect (send "let x = 1;; let y = 2;;")
-                :to-equal '("input-multi:\n"
-                            "data:let x = 1;; let y = 2;;\n"
-                            "end:\n")))
+    (it "does not double a present `;;'"
+      (expect (send "let x = 1;;")
+              :to-equal '("input-multi:\n"
+                          "data:let x = 1;;\n"
+                          "end:\n")))
 
-      (it "splits a multi-line phrase into one data line per line"
-        (expect (send "let x =\n  1 + 1")
-                :to-equal '("input-multi:\n"
-                            "data:let x =\n"
-                            "data:  1 + 1;;\n"
-                            "end:\n"))))))
+    (it "sends every phrase of a multi-phrase region"
+      ;; input-multi means both phrases evaluate, not just the first.
+      (expect (send "let x = 1;; let y = 2;;")
+              :to-equal '("input-multi:\n"
+                          "data:let x = 1;; let y = 2;;\n"
+                          "end:\n")))
+
+    (it "splits a multi-line phrase into one data line per line"
+      (expect (send "let x =\n  1 + 1")
+              :to-equal '("input-multi:\n"
+                          "data:let x =\n"
+                          "data:  1 + 1;;\n"
+                          "end:\n")))))
 
 (describe "neocaml-utop protocol line handling"
   (it "renders stdout verbatim"

--- a/test/neocaml-utop-test.el
+++ b/test/neocaml-utop-test.el
@@ -139,7 +139,8 @@
       (neocaml-utop--handle-line "completion:map2")
       (neocaml-utop--handle-line "completion-stop:")
       (expect neocaml-utop--completion-state :to-equal 'done)
-      (expect (reverse neocaml-utop--completions) :to-equal '("map" "map2")))))
+      ;; the collection order is an internal detail; assert the set
+      (expect neocaml-utop--completions :to-have-same-items-as '("map" "map2")))))
 
 (describe "neocaml-utop result echo"
   (cl-flet ((capture-message (thunk)

--- a/test/neocaml-utop-test.el
+++ b/test/neocaml-utop-test.el
@@ -190,155 +190,114 @@
                 :to-be nil)))))
 
 (describe "neocaml-utop error overlays"
-  (it "underlines the exact character range reported by accept"
-    (let ((source (generate-new-buffer "src"))
-          (transcript (generate-new-buffer "tr")))
-      (unwind-protect
-          (progn
-            (with-current-buffer source
-              (insert "let y = 1 + \"a\""))
-            (with-current-buffer transcript
-              ;; (BUFFER START END): offsets are relative to position 1
-              (setq neocaml-utop--error-target (list source 1 999))
-              (neocaml-utop--handle-accept "12,15")
-              (expect (length neocaml-utop--overlays) :to-equal 1)
-              (let ((ov (car neocaml-utop--overlays)))
-                (expect (with-current-buffer source
-                          (buffer-substring-no-properties
-                           (overlay-start ov) (overlay-end ov)))
-                        :to-equal "\"a\"")
-                (expect (overlay-get ov 'face) :to-equal 'neocaml-utop-error-face))))
-        (kill-buffer source)
-        (kill-buffer transcript))))
+  (let (source transcript)
+    (before-each
+      (setq source (neocaml-test-track-buffer (generate-new-buffer "src"))
+            transcript (neocaml-test-track-buffer (generate-new-buffer "tr"))))
+    (after-each (neocaml-test-kill-tracked-buffers))
 
-  (it "maps character offsets correctly across multibyte source"
-    ;; utop reports character offsets, not bytes; a multibyte char before
-    ;; the error span must not shift the overlay.
-    (let ((source (generate-new-buffer "src"))
-          (transcript (generate-new-buffer "tr")))
-      (unwind-protect
-          (progn
-            (with-current-buffer source
-              (insert "let x = \"héllo\" + 1"))
-            (with-current-buffer transcript
-              (setq neocaml-utop--error-target (list source 1 999))
-              (neocaml-utop--handle-accept "8,15")
-              (expect (length neocaml-utop--overlays) :to-equal 1)
-              (let ((ov (car neocaml-utop--overlays)))
-                (expect (with-current-buffer source
-                          (buffer-substring-no-properties
-                           (overlay-start ov) (overlay-end ov)))
-                        :to-equal "\"héllo\""))))
-        (kill-buffer source)
-        (kill-buffer transcript))))
+    (it "underlines the exact character range reported by accept"
+      (with-current-buffer source (insert "let y = 1 + \"a\""))
+      (with-current-buffer transcript
+        ;; (BUFFER START END): offsets are relative to position 1
+        (setq neocaml-utop--error-target (list source 1 999))
+        (neocaml-utop--handle-accept "12,15")
+        (expect (length neocaml-utop--overlays) :to-equal 1)
+        (let ((ov (car neocaml-utop--overlays)))
+          (expect (with-current-buffer source
+                    (buffer-substring-no-properties
+                     (overlay-start ov) (overlay-end ov)))
+                  :to-equal "\"a\"")
+          (expect (overlay-get ov 'face) :to-equal 'neocaml-utop-error-face))))
 
-  (it "does not crash or overshoot when offsets run past the phrase"
-    ;; `let x = 1 +' + appended `;;' makes utop report accept:11,13; with
-    ;; an 11-char source those offsets must clamp away rather than signal.
-    (let ((source (generate-new-buffer "src"))
-          (transcript (generate-new-buffer "tr")))
-      (unwind-protect
-          (progn
-            (with-current-buffer source (insert "let x = 1 +"))
-            (with-current-buffer transcript
-              (setq neocaml-utop--error-target
-                    (list source 1 (with-current-buffer source (point-max))))
-              (neocaml-utop--handle-accept "11,13")
-              (expect neocaml-utop--overlays :to-be nil)))
-        (kill-buffer source)
-        (kill-buffer transcript))))
+    (it "maps character offsets correctly across multibyte source"
+      ;; utop reports character offsets, not bytes; a multibyte char before
+      ;; the error span must not shift the overlay.
+      (with-current-buffer source (insert "let x = \"héllo\" + 1"))
+      (with-current-buffer transcript
+        (setq neocaml-utop--error-target (list source 1 999))
+        (neocaml-utop--handle-accept "8,15")
+        (expect (length neocaml-utop--overlays) :to-equal 1)
+        (let ((ov (car neocaml-utop--overlays)))
+          (expect (with-current-buffer source
+                    (buffer-substring-no-properties
+                     (overlay-start ov) (overlay-end ov)))
+                  :to-equal "\"héllo\""))))
 
-  (it "clears overlays on a clean accept"
-    (let ((source (generate-new-buffer "src"))
-          (transcript (generate-new-buffer "tr")))
-      (unwind-protect
-          (progn
-            (with-current-buffer source (insert "let y = 1 + \"a\""))
-            (with-current-buffer transcript
-              (setq neocaml-utop--error-target (list source 1 999))
-              (neocaml-utop--handle-accept "12,15")
-              (expect (length neocaml-utop--overlays) :to-equal 1)
-              (neocaml-utop--handle-accept "")
-              (expect neocaml-utop--overlays :to-be nil)))
-        (kill-buffer source)
-        (kill-buffer transcript))))
+    (it "does not crash or overshoot when offsets run past the phrase"
+      ;; `let x = 1 +' + appended `;;' makes utop report accept:11,13; with
+      ;; an 11-char source those offsets must clamp away rather than signal.
+      (with-current-buffer source (insert "let x = 1 +"))
+      (with-current-buffer transcript
+        (setq neocaml-utop--error-target
+              (list source 1 (with-current-buffer source (point-max))))
+        (neocaml-utop--handle-accept "11,13")
+        (expect neocaml-utop--overlays :to-be nil)))
 
-  (it "attaches the following stderr text as the overlay tooltip"
-    (let ((source (generate-new-buffer "src"))
-          (transcript (generate-new-buffer "tr")))
-      (unwind-protect
-          (progn
-            (with-current-buffer source (insert "let y = 1 + \"a\""))
-            (with-current-buffer transcript
-              (setq neocaml-utop--error-target (list source 1 999))
-              (neocaml-utop--handle-accept "12,15")
-              ;; the error message arrives next, on stderr
-              (neocaml-utop--handle-line "stderr:Error: This expression has type string")
-              (expect (overlay-get (car neocaml-utop--overlays) 'help-echo)
-                      :to-equal "Error: This expression has type string")))
-        (kill-buffer source)
-        (kill-buffer transcript))))
+    (it "clears overlays on a clean accept"
+      (with-current-buffer source (insert "let y = 1 + \"a\""))
+      (with-current-buffer transcript
+        (setq neocaml-utop--error-target (list source 1 999))
+        (neocaml-utop--handle-accept "12,15")
+        (expect (length neocaml-utop--overlays) :to-equal 1)
+        (neocaml-utop--handle-accept "")
+        (expect neocaml-utop--overlays :to-be nil)))
 
-  (it "clears an error overlay when the underlined text is edited"
-    (let ((source (generate-new-buffer "src"))
-          (transcript (generate-new-buffer "tr")))
-      (unwind-protect
-          (progn
-            (with-current-buffer source (insert "let y = 1 + \"a\""))
-            (with-current-buffer transcript
-              (setq neocaml-utop--error-target (list source 1 999))
-              (neocaml-utop--handle-accept "12,15"))
-            (let ((ov (car (buffer-local-value 'neocaml-utop--overlays transcript))))
-              (expect (overlay-buffer ov) :to-equal source)
-              ;; edit inside the underlined span
-              (with-current-buffer source
-                (goto-char 14)
-                (insert "X"))
-              (expect (overlay-buffer ov) :to-be nil)))
-        (kill-buffer source)
-        (kill-buffer transcript)))))
+    (it "attaches the following stderr text as the overlay tooltip"
+      (with-current-buffer source (insert "let y = 1 + \"a\""))
+      (with-current-buffer transcript
+        (setq neocaml-utop--error-target (list source 1 999))
+        (neocaml-utop--handle-accept "12,15")
+        ;; the error message arrives next, on stderr
+        (neocaml-utop--handle-line "stderr:Error: This expression has type string")
+        (expect (overlay-get (car neocaml-utop--overlays) 'help-echo)
+                :to-equal "Error: This expression has type string")))
+
+    (it "clears an error overlay when the underlined text is edited"
+      (with-current-buffer source (insert "let y = 1 + \"a\""))
+      (with-current-buffer transcript
+        (setq neocaml-utop--error-target (list source 1 999))
+        (neocaml-utop--handle-accept "12,15"))
+      (let ((ov (car (buffer-local-value 'neocaml-utop--overlays transcript))))
+        (expect (overlay-buffer ov) :to-equal source)
+        ;; edit inside the underlined span
+        (with-current-buffer source
+          (goto-char 14)
+          (insert "X"))
+        (expect (overlay-buffer ov) :to-be nil)))))
 
 (describe "neocaml-utop inline result overlay"
-  (it "shows the value as an after-string at the region's end of line"
-    (let ((source (generate-new-buffer "src"))
-          (transcript (generate-new-buffer "tr")))
-      (unwind-protect
-          (progn
-            (with-current-buffer source (insert "let x = 1 + 1"))
-            (with-current-buffer transcript
-              (neocaml-utop--inline-result
-               '((out . "val x : int = 2")) (list source 1 14) transcript)
-              (expect (length neocaml-utop--result-overlays) :to-equal 1)
-              (let ((ov (car neocaml-utop--result-overlays)))
-                (expect (overlay-buffer ov) :to-equal source)
-                (expect (overlay-get ov 'after-string)
-                        :to-equal (propertize "  => val x : int = 2"
-                                              'face 'neocaml-utop-result-face)))))
-        (kill-buffer source)
-        (kill-buffer transcript))))
+  (let (source transcript)
+    (before-each
+      (setq source (neocaml-test-track-buffer (generate-new-buffer "src"))
+            transcript (neocaml-test-track-buffer (generate-new-buffer "tr"))))
+    (after-each (neocaml-test-kill-tracked-buffers))
 
-  (it "shows nothing for interactive input (target is the transcript)"
-    (let ((transcript (generate-new-buffer "tr")))
-      (unwind-protect
-          (with-current-buffer transcript
-            (insert "let x = 1 + 1")
-            (neocaml-utop--inline-result
-             '((out . "val x : int = 2")) (list transcript 1 14) transcript)
-            (expect neocaml-utop--result-overlays :to-be nil))
-        (kill-buffer transcript))))
+    (it "shows the value as an after-string at the region's end of line"
+      (with-current-buffer source (insert "let x = 1 + 1"))
+      (with-current-buffer transcript
+        (neocaml-utop--inline-result
+         '((out . "val x : int = 2")) (list source 1 14) transcript)
+        (expect (length neocaml-utop--result-overlays) :to-equal 1)
+        (let ((ov (car neocaml-utop--result-overlays)))
+          (expect (overlay-buffer ov) :to-equal source)
+          (expect (overlay-get ov 'after-string)
+                  :to-equal (propertize "  => val x : int = 2"
+                                        'face 'neocaml-utop-result-face)))))
 
-  (it "shows nothing when the result is only an error"
-    (let ((source (generate-new-buffer "src"))
-          (transcript (generate-new-buffer "tr")))
-      (unwind-protect
-          (progn
-            (with-current-buffer source (insert "let x = 1"))
-            (with-current-buffer transcript
-              (neocaml-utop--inline-result
-               '((err . "Error: boom")) (list source 1 10) transcript)
-              (expect neocaml-utop--result-overlays :to-be nil)))
-        (kill-buffer source)
-        (kill-buffer transcript)))))
+    (it "shows nothing for interactive input (target is the transcript)"
+      (with-current-buffer transcript
+        (insert "let x = 1 + 1")
+        (neocaml-utop--inline-result
+         '((out . "val x : int = 2")) (list transcript 1 14) transcript)
+        (expect neocaml-utop--result-overlays :to-be nil)))
+
+    (it "shows nothing when the result is only an error"
+      (with-current-buffer source (insert "let x = 1"))
+      (with-current-buffer transcript
+        (neocaml-utop--inline-result
+         '((err . "Error: boom")) (list source 1 10) transcript)
+        (expect neocaml-utop--result-overlays :to-be nil)))))
 
 (describe "neocaml-utop input completeness"
   (it "treats a `;;'-terminated phrase as complete"
@@ -379,6 +338,8 @@
     (unless (executable-find "utop")
       (signal 'buttercup-pending "utop not installed")))
 
+  (after-each (neocaml-test-kill-tracked-buffers))
+
   (cl-flet ((contents (buf)
               (with-current-buffer buf
                 (buffer-substring-no-properties (point-min) (point-max))))
@@ -386,107 +347,90 @@
               (let ((end (+ (float-time) 20)))
                 (while (and (not (funcall pred)) (< (float-time) end))
                   (accept-process-output nil 0.05))
-                (funcall pred)))
-            (cleanup (transcript source)
-              (when (buffer-live-p transcript)
-                (when-let* ((proc (get-buffer-process transcript)))
-                  (set-process-query-on-exit-flag proc nil)
-                  (delete-process proc))
-                (kill-buffer transcript))
-              (when (buffer-live-p source) (kill-buffer source))))
+                (funcall pred))))
 
     (it "evaluates a phrase and shows the result"
       ;; Bind the history file off so tests never touch the user's history.
       (let ((neocaml-utop-history-file nil)
-            (source (generate-new-buffer "src.ml"))
+            (source (neocaml-test-track-buffer (generate-new-buffer "src.ml")))
             transcript)
-        (unwind-protect
-            (with-current-buffer source
-              (insert "let x = 1 + 1")
-              (setq transcript (neocaml-utop--get-or-create))
-              (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
-                      :to-be-truthy)
-              (neocaml-utop-send-region (point-min) (point-max))
-              (expect (wait (lambda () (string-match-p "val x : int = 2" (contents transcript))))
-                      :to-be-truthy))
-          (cleanup transcript source))))
+        (with-current-buffer source
+          (insert "let x = 1 + 1")
+          (setq transcript (neocaml-test-track-buffer (neocaml-utop--get-or-create)))
+          (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
+                  :to-be-truthy)
+          (neocaml-utop-send-region (point-min) (point-max))
+          (expect (wait (lambda () (string-match-p "val x : int = 2" (contents transcript))))
+                  :to-be-truthy))))
 
     (it "evaluates every phrase of a multi-phrase region"
       ;; Regression: with plain `input' only the first phrase ran.
       (let ((neocaml-utop-history-file nil)
-            (source (generate-new-buffer "src.ml"))
+            (source (neocaml-test-track-buffer (generate-new-buffer "src.ml")))
             transcript)
-        (unwind-protect
-            (with-current-buffer source
-              (insert "let x = 1;; let y = 2;;")
-              (setq transcript (neocaml-utop--get-or-create))
-              (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
-                      :to-be-truthy)
-              (neocaml-utop-send-region (point-min) (point-max))
-              (expect (wait (lambda ()
-                              (and (string-match-p "val x : int = 1" (contents transcript))
-                                   (string-match-p "val y : int = 2" (contents transcript)))))
-                      :to-be-truthy))
-          (cleanup transcript source))))
+        (with-current-buffer source
+          (insert "let x = 1;; let y = 2;;")
+          (setq transcript (neocaml-test-track-buffer (neocaml-utop--get-or-create)))
+          (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
+                  :to-be-truthy)
+          (neocaml-utop-send-region (point-min) (point-max))
+          (expect (wait (lambda ()
+                          (and (string-match-p "val x : int = 1" (contents transcript))
+                               (string-match-p "val y : int = 2" (contents transcript)))))
+                  :to-be-truthy))))
 
     (it "echoes a source evaluation's result in the minibuffer"
       (let ((neocaml-utop-history-file nil)
             (neocaml-utop-echo-eval-result t)
-            (source (generate-new-buffer "src.ml"))
+            (source (neocaml-test-track-buffer (generate-new-buffer "src.ml")))
             transcript messages)
-        (unwind-protect
-            (with-current-buffer source
-              (insert "let x = 1 + 1")
-              (setq transcript (neocaml-utop--get-or-create))
-              (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
-                      :to-be-truthy)
-              (cl-letf (((symbol-function 'message)
-                         (lambda (fmt &rest args)
-                           (when (stringp fmt) (push (apply #'format fmt args) messages)))))
-                (neocaml-utop-send-region (point-min) (point-max))
-                (wait (lambda ()
-                        (seq-find (lambda (m) (string-match-p "val x : int = 2" m))
-                                  messages))))
-              (expect (seq-find (lambda (m) (string-match-p "val x : int = 2" m)) messages)
-                      :to-be-truthy))
-          (cleanup transcript source))))
+        (with-current-buffer source
+          (insert "let x = 1 + 1")
+          (setq transcript (neocaml-test-track-buffer (neocaml-utop--get-or-create)))
+          (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
+                  :to-be-truthy)
+          (cl-letf (((symbol-function 'message)
+                     (lambda (fmt &rest args)
+                       (when (stringp fmt) (push (apply #'format fmt args) messages)))))
+            (neocaml-utop-send-region (point-min) (point-max))
+            (wait (lambda ()
+                    (seq-find (lambda (m) (string-match-p "val x : int = 2" m))
+                              messages))))
+          (expect (seq-find (lambda (m) (string-match-p "val x : int = 2" m)) messages)
+                  :to-be-truthy))))
 
     (it "underlines a type error precisely in the source"
       (let ((neocaml-utop-history-file nil)
-            (source (generate-new-buffer "src.ml"))
+            (source (neocaml-test-track-buffer (generate-new-buffer "src.ml")))
             transcript)
-        (unwind-protect
-            (with-current-buffer source
-              (insert "let y = 1 + \"a\"")
-              (setq transcript (neocaml-utop--get-or-create))
-              (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
-                      :to-be-truthy)
-              (neocaml-utop-send-region (point-min) (point-max))
-              (expect (wait (lambda () (string-match-p "type int" (contents transcript))))
-                      :to-be-truthy)
-              (let ((errs (seq-filter
-                           (lambda (o) (eq (overlay-get o 'face) 'neocaml-utop-error-face))
-                           (overlays-in (point-min) (point-max)))))
-                (expect (length errs) :to-equal 1)
-                (expect (buffer-substring-no-properties
-                         (overlay-start (car errs)) (overlay-end (car errs)))
-                        :to-equal "\"a\"")))
-          (cleanup transcript source))))
+        (with-current-buffer source
+          (insert "let y = 1 + \"a\"")
+          (setq transcript (neocaml-test-track-buffer (neocaml-utop--get-or-create)))
+          (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
+                  :to-be-truthy)
+          (neocaml-utop-send-region (point-min) (point-max))
+          (expect (wait (lambda () (string-match-p "type int" (contents transcript))))
+                  :to-be-truthy)
+          (let ((errs (seq-filter
+                       (lambda (o) (eq (overlay-get o 'face) 'neocaml-utop-error-face))
+                       (overlays-in (point-min) (point-max)))))
+            (expect (length errs) :to-equal 1)
+            (expect (buffer-substring-no-properties
+                     (overlay-start (car errs)) (overlay-end (car errs)))
+                    :to-equal "\"a\"")))))
 
     (it "returns completion candidates from utop"
       (let ((neocaml-utop-history-file nil)
-            (source (generate-new-buffer "src.ml"))
+            (source (neocaml-test-track-buffer (generate-new-buffer "src.ml")))
             transcript)
-        (unwind-protect
-            (with-current-buffer source
-              (setq transcript (neocaml-utop--get-or-create))
-              (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
-                      :to-be-truthy)
-              (with-current-buffer transcript
-                (goto-char (point-max))
-                (let ((cands (neocaml-utop--complete "List.ma")))
-                  (expect (member "map" cands) :to-be-truthy))))
-          (cleanup transcript source))))))
+        (with-current-buffer source
+          (setq transcript (neocaml-test-track-buffer (neocaml-utop--get-or-create)))
+          (expect (wait (lambda () (string-match-p "utop\\[0\\]> " (contents transcript))))
+                  :to-be-truthy)
+          (with-current-buffer transcript
+            (goto-char (point-max))
+            (let ((cands (neocaml-utop--complete "List.ma")))
+              (expect (member "map" cands) :to-be-truthy))))))))
 
 (provide 'neocaml-utop-test)
 


### PR DESCRIPTION
Follow-up to the `:to-have-face` matcher, applying the rest of the buttercup-idiom cleanups from that review. One commit per item:

- **spy-on instead of cl-letf** for function stubs. Auto-restores after each spec and lets us assert calls directly - the `neocaml--check-build-dir` tests drop their manual `prompted` flag for `(expect 'y-or-n-p :to-have-been-called)`, and the objinfo revert test uses `:to-have-been-called-times`. The `message`-capturing stubs in the utop echo tests stay on `cl-letf` on purpose (spying the logging function itself is the one case where a scoped let is clearer and safer).
- **after-each teardown** replacing hand-rolled `unwind-protect` buffer/process cleanup. A small `neocaml-test-track-buffer` / `neocaml-test-kill-tracked-buffers` pair in the shared helpers backs it; the utop overlay suites now create their buffers in a `before-each`, so each spec is just its assertions. (The temp-directory `unwind-protect`s elsewhere are legitimate resource cleanup and left alone.)
- **:to-have-same-items-as** where a test means "exactly this set": the utop completion-accumulation test drops a `reverse`, and the dune local-libraries scan collapses three member/not-member checks into one set assertion. Most completion tests already use `member` for "offers X here" and stay as is.

No production code changes; 558 specs, unchanged behavior.