### PR TITLE
" nodes should not be sexps?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug fixes
 
+- [#78](https://github.com/bbatsov/neocaml/pull/78): Don't treat `"` and `'` delimiter nodes as sexps, so `treesit-thing-at` before a string or char literal returns the whole literal instead of the bare quote.
 - [#79](https://github.com/bbatsov/neocaml/pull/79): Fix a segfault on Emacs 31.1 when font-locking a buffer containing a builtin type or value (`let x : int = 42` was enough to trigger it).
 
 ## 0.10.0 (2026-07-10)

--- a/neocaml.el
+++ b/neocaml.el
@@ -1235,7 +1235,7 @@ This makes commands like `delete-pair' work correctly."
   `((,language
      (sexp (not ,(rx (or "{" "}" "(" ")" "[" "]" "[|" "|]"
                          "," "." ";" ";;" ":" "::" ":>" "->"
-                         "<-" "=" "|" ".."))))
+                         "<-" "=" "|" ".." "\"" "'"))))
      (list ,neocaml--list-node-regex)
      (sentence ,(regexp-opt '("value_definition"
                               "type_definition"

--- a/test/neocaml-thing-at-test.el
+++ b/test/neocaml-thing-at-test.el
@@ -1,0 +1,27 @@
+;;; neocaml-thing-at-test.el --- Tests for `treesit-thing-at' -*- lexical-binding: t; -*-
+
+(require 'neocaml-test-helpers)
+
+;; sexp
+
+(describe "sexp at point"
+  (it "works at the beginning of strings"
+    (with-neocaml-buffer "let x = \"hello\""
+      (search-forward "= ")
+      (expect (treesit-node-text (treesit-thing-at (point) 'sexp))
+              :to-equal "\"hello\"")))
+
+  (it "works for characters"
+    (with-neocaml-buffer "let x = 'a'"
+      (search-forward "= ")
+      (expect (treesit-node-text (treesit-thing-at (point) 'sexp))
+              :to-equal "'a'")))
+
+  (it "works for quoted strings"
+    (with-neocaml-buffer "let x = {|hello|}"
+      (search-forward "= ")
+      (expect (treesit-node-text (treesit-thing-at (point) 'sexp))
+              :to-equal "{|hello|}"))))
+
+
+

--- a/test/neocaml-thing-at-test.el
+++ b/test/neocaml-thing-at-test.el
@@ -1,10 +1,27 @@
 ;;; neocaml-thing-at-test.el --- Tests for `treesit-thing-at' -*- lexical-binding: t; -*-
 
+;; Copyright © 2025-2026 Bozhidar Batsov
+
+;;; Commentary:
+
+;; Buttercup tests for the `sexp' thing in `neocaml--thing-settings':
+;; string, character, and quoted-string literals should resolve to the
+;; whole literal node, not their delimiter tokens.
+
+;;; Code:
+
+(require 'buttercup)
+(require 'neocaml)
 (require 'neocaml-test-helpers)
 
-;; sexp
-
 (describe "sexp at point"
+  (before-all
+    (unless (treesit-language-available-p 'ocaml)
+      (signal 'buttercup-pending "tree-sitter OCaml grammar not available"))
+    ;; `treesit-thing-at' arrived in Emacs 30.
+    (unless (fboundp 'treesit-thing-at)
+      (signal 'buttercup-pending "treesit-thing-at not available")))
+
   (it "works at the beginning of strings"
     (with-neocaml-buffer "let x = \"hello\""
       (search-forward "= ")
@@ -23,5 +40,6 @@
       (expect (treesit-node-text (treesit-thing-at (point) 'sexp))
               :to-equal "{|hello|}"))))
 
+(provide 'neocaml-thing-at-test)
 
-
+;;; neocaml-thing-at-test.el ends here


### PR DESCRIPTION
Right now `(treesit-thing-at (point) 'sexp)` with point before the opening quote of a string returns the node corresponding to the quote only, which I assume is a bug?