### PR TITLE
Add dape native debugging setup

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -6,6 +6,9 @@ Debug Adapter Protocol client, available from GNU ELPA) and
 debugging. When dape is loaded, neocaml automatically registers its modes with
 dape's built-in `ocamlearlybird` configuration.
 
+ocamlearlybird debugs **bytecode**. For **native** executables built by
+`ocamlopt`, see [Native debugging](#native-debugging-lldb-gdb) below.
+
 ## Setup
 
 1. Install ocamlearlybird:
@@ -47,6 +50,36 @@ Once the session starts, dape provides the standard debugging commands:
 | `dape-info` | | Show debugger info (variables, stack, breakpoints) |
 | `dape-repl` | | Open the debug REPL |
 | `dape-quit` | `C-x C-a q` | Stop the debug session |
+
+## Native debugging (lldb, gdb)
+
+ocamlearlybird cannot attach to native executables. For those, use a native
+debugger through dape's `lldb-dap` configuration (macOS, Linux) or `gdb`
+(Linux; dape requires gdb >= 14.1). neocaml registers its modes with these
+configurations too, so they appear at the `M-x dape` prompt in OCaml buffers.
+
+Compile with debug information -- in your `dune` file:
+
+```
+(executable
+ (name main)
+ (ocamlopt_flags (:standard -g)))
+```
+
+Then `dune build`, and start a session with `M-x dape`, choosing `lldb-dap`
+(or `gdb`) and pointing `:program` at `_build/default/bin/main.exe`.
+
+Everything past that -- symbol mangling, setting breakpoints, reading
+backtraces, and inspecting OCaml values with the `tools/gdb.py` and
+`tools/lldb.py` helper scripts -- is covered by the
+[Native debugging chapter](https://ocaml.org/manual/5.5/native-debugger.html)
+of the OCaml manual. Two settings from it are worth knowing up front, because
+dune's build layout makes them likely:
+
+- if the debugger cannot find your sources, set `target.source-map` (lldb) or
+  use `directory` (gdb) to redirect the recorded paths
+- build dependencies with `OPAMKEEPBUILDDIR=1` so their sources remain
+  available for source-level debugging
 
 ## Caveats
 

--- a/neocaml.el
+++ b/neocaml.el
@@ -1805,15 +1805,25 @@ the language-specific parts of the mode."
                      :language-id "ocaml.interface"))
                    "ocamllsp"))))
 
+(defconst neocaml--dape-config-names
+  '(ocamlearlybird lldb-dap lldb-vscode gdb)
+  "Names of `dape-configs' entries that should be offered in OCaml buffers.
+`ocamlearlybird' debugs bytecode executables; the rest are native
+debuggers that work on `ocamlopt'-built executables.  dape filters
+its suggestions by major mode, so these need `neocaml-mode' added
+to their `modes' to show up at the `dape' prompt.")
+
 (defun neocaml--register-with-dape ()
-  "Register neocaml modes with dape's ocamlearlybird config if loaded."
+  "Register neocaml modes with dape configurations if dape is loaded.
+The configurations are listed in `neocaml--dape-config-names'."
   (when (boundp 'dape-configs)
-    (when-let* ((cfg (alist-get 'ocamlearlybird dape-configs)))
-      (let ((modes (plist-get cfg 'modes)))
-        (unless (memq 'neocaml-mode modes)
-          (plist-put cfg 'modes
-                     (append '(neocaml-mode neocaml-interface-mode)
-                             modes)))))))
+    (dolist (name neocaml--dape-config-names)
+      (when-let* ((cfg (alist-get name dape-configs)))
+        (let ((modes (plist-get cfg 'modes)))
+          (unless (memq 'neocaml-mode modes)
+            (plist-put cfg 'modes
+                       (append '(neocaml-mode neocaml-interface-mode)
+                               modes))))))))
 
 (define-derived-mode neocaml-base-mode prog-mode "OCaml"
   "Base major mode for OCaml files, providing shared setup.


### PR DESCRIPTION
Opening as a DRAFT and sharing here while I dog-food the LLDB support in OCaml/OxCaml. The state of native debugging is included in the OCaml manual along with its limitations. 